### PR TITLE
refactor: 解構 dashboard.js 以提升模組化與可維護性 (v9.0 MultiAgent)

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -7,9 +7,11 @@
  * 2. 👥 新增 MultiAgent 活動監控 (青色顯示)。
  * 3. 🎨 介面標題與狀態更新，保留所有 v8.6 功能。
  */
-const blessed = require('blessed');
-const contrib = require('blessed-contrib');
 const os = require('os');
+const TerminalView = require('./src/views/TerminalView');
+const DashboardManager = require('./src/managers/DashboardManager');
+const ConsoleInterceptor = require('./src/utils/ConsoleInterceptor');
+
 let WebServer = null;
 try {
     WebServer = require('./web-dashboard/server');
@@ -19,211 +21,107 @@ try {
 
 class DashboardPlugin {
     constructor() {
-        // 1. 保存原始的 Console 方法
-        this.originalLog = console.log;
-        this.originalError = console.error;
-        this.isDetached = false;
+        // 1. 保存原始的 Console 方法並初始化 UI 元件與管理器
+        this.manager = new DashboardManager();
+        // 初始化螢幕
+        this.view = new TerminalView({
+            title: '🦞 Golem v9.0 戰術控制台 (MultiAgent Edition)',
+            onExit: () => this.detach()
+        });
 
-        // 狀態追蹤
-        this.queueCount = 0;
-        this.lastSchedule = "無排程";
+        // 啟動 Web Server (保留 v8.6 Web 介面功能)
+        this._initWebServer();
 
-        // Web Server Init (保留 v8.6 Web 介面功能)
+        // 6. 啟動攔截器 (Hijack Console)
+        ConsoleInterceptor.hijack({
+            onLog: (args) => this._handleLog(args),
+            onError: (args) => this._handleError(args)
+        });
+
+        this.startMonitoring();
+    }
+
+    _initWebServer() {
         if (process.env.ENABLE_WEB_DASHBOARD === 'true' && WebServer) {
             try {
                 this.webServer = new WebServer(this);
             } catch (e) {
                 console.error("❌ Failed to start Web Dashboard:", e.message);
-                this.webServer = null;
             }
-        } else {
-            this.webServer = null;
         }
-
-        // 2. 初始化螢幕
-        this.screen = blessed.screen({
-            smartCSR: true,
-            title: '🦞 Golem v9.0 戰術控制台 (MultiAgent Edition)',
-            fullUnicode: true
-        });
-
-        // 3. 建立網格 (12x12)
-        this.grid = new contrib.grid({ rows: 12, cols: 12, screen: this.screen });
-
-        // --- 介面元件佈局 ---
-
-        // [左上] 系統心跳 (CPU/RAM)
-        this.cpuLine = this.grid.set(0, 0, 4, 8, contrib.line, {
-            style: { line: "yellow", text: "green", baseline: "black" },
-            label: '⚡ 系統核心 (System Core)',
-            showLegend: true
-        });
-
-        // [右上] 狀態概覽 (Status)
-        this.statusBox = this.grid.set(0, 8, 4, 4, contrib.markdown, {
-            label: '📊 狀態 (Status)',
-            tags: true,
-            style: { border: { fg: 'cyan' } }
-        });
-
-        // [中層] 時序雷達 (Chronos Log) - 專門顯示排程與時間相關資訊
-        this.chronosLog = this.grid.set(4, 0, 3, 6, contrib.log, {
-            fg: "green",
-            selectedFg: "green",
-            label: '⏰ 時序雷達 (Chronos Radar)'
-        });
-
-        // [中層] 隊列監控 (Queue Log) - 顯示對話進出與 Agent 會議
-        this.queueLog = this.grid.set(4, 6, 3, 6, contrib.log, {
-            fg: "magenta",
-            selectedFg: "magenta",
-            label: '🚦 隊列交通 (Traffic & Agents)'
-        });
-
-        // [底層] 全域日誌 (Global Log)
-        this.logBox = this.grid.set(7, 0, 5, 12, contrib.log, {
-            fg: "white",
-            selectedFg: "white",
-            label: '📝 核心日誌 (Neuro-Link Stream)'
-        });
-
-        // 4. 資料初始化
-        this.memData = { title: 'Memory (MB)', x: Array(60).fill(0).map((_, i) => i.toString()), y: Array(60).fill(0) };
-
-        // 5. 綁定按鍵
-        this.screen.key(['escape', 'q', 'C-c'], () => this.detach());
-
-        // 6. 啟動攔截器
-        this.hijackConsole();
-        this.startMonitoring();
-        this.screen.render();
     }
 
-    hijackConsole() {
-        console.log = (...args) => {
-            this.originalLog.apply(console, args); // 保持原輸出
-            if (this.isDetached) return;
+    _handleLog(args) {
+        if (this.manager.state.isDetached) return;
 
-            const msg = args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ');
-            const time = new Date().toLocaleTimeString();
-            const formattedMsg = `{gray-fg}[${time}]{/gray-fg} ${msg}`;
+        const { type, msg, cleanMsg, raw } = this.manager.dispatchLog(args);
+        const time = new Date().toLocaleTimeString();
 
-            // Strip blessed tags and ANSI codes for clean processing
-            // eslint-disable-next-line no-control-regex
-            const cleanMsg = msg.replace(/\u001b\[.*?m/g, '').replace(/\{.*?\}/g, '');
-
-            // Web Socket Emission
-            if (this.webServer) {
-                let type = 'general';
-                if (cleanMsg.includes('Error') || cleanMsg.includes('❌')) type = 'error';
-                else if (cleanMsg.includes('[MultiAgent]')) type = 'agent';
-                else if (cleanMsg.includes('[Chronos]') || cleanMsg.includes('排程')) type = 'chronos';
-                else if (cleanMsg.includes('[Queue]') || cleanMsg.includes('隊列')) type = 'queue';
-
-                this.webServer.broadcastLog({
-                    time: time,
-                    msg: cleanMsg.trim(),
-                    type: type,
-                    raw: msg
-                });
-            }
-
-            // 分流邏輯
-            // 分流邏輯
-            if (cleanMsg.includes('[Chronos]') || cleanMsg.includes('排程') || cleanMsg.includes('TimeWatcher')) {
-                // 保留 Chronos 監控
-                if (this.chronosLog) this.chronosLog.log(`{yellow-fg}${msg}{/yellow-fg}`);
-                if (cleanMsg.includes('新增排程')) {
-                    // Fix: Use cleanMsg to avoid ANSI issues and trim result
-                    const scheduleText = cleanMsg.split('新增排程:')[1] || "更新中...";
-                    this.lastSchedule = scheduleText.trim();
-                    if (this.webServer) {
-                        this.webServer.broadcastState({ lastSchedule: this.lastSchedule });
-                    }
-                }
-            }
-            // v9.0 新增：捕捉 MultiAgent 會議紀錄，並導向 QueueLog 以區隔顯示
-            else if (msg.includes('[InteractiveMultiAgent]') || msg.includes('[MultiAgent]')) {
-                if (this.queueLog) this.queueLog.log(`{cyan-fg}${msg}{/cyan-fg}`);
-            }
-            else if (msg.includes('[Queue]') || msg.includes('隊列')) {
-                // 保留原有 Queue 監控
-                if (this.queueLog) this.queueLog.log(`{magenta-fg}${msg}{/magenta-fg}`);
-                // 簡單的狀態解析
-                if (msg.includes('加入隊列')) this.queueCount++;
-                if (msg.includes('開始處理')) this.queueCount = Math.max(0, this.queueCount - 1);
-
-                if (this.webServer) this.webServer.broadcastState({ queueCount: this.queueCount });
-            }
-
-            // 全域顯示
-            if (this.logBox) this.logBox.log(formattedMsg);
+        // 更新 UI (使用與原始代碼一致的著色標籤)
+        const tags = {
+            chronos: { start: '{yellow-fg}', end: '{/yellow-fg}' },
+            agent: { start: '{cyan-fg}', end: '{/cyan-fg}' },
+            queue: { start: '{magenta-fg}', end: '{/magenta-fg}' }
         };
 
-        console.error = (...args) => {
-            this.originalError.apply(console, args);
-            if (this.isDetached) return;
-            const msg = args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ');
-            if (this.logBox) this.logBox.log(`{red-fg}[錯誤] ${msg}{/red-fg}`);
-            if (this.webServer) this.webServer.broadcastLog({ time: new Date().toLocaleTimeString(), msg: msg, type: 'error' });
-        };
-    }
+        const tag = tags[type] || { start: '', end: '' };
+        this.view.log(type, `${tag.start}${raw}${tag.end}`);
 
-    detach() {
-        this.isDetached = true;
-        this.screen.destroy();
-        console.log = this.originalLog;
-        console.error = this.originalError;
-
+        // Web 廣播
         if (this.webServer) {
-            this.webServer.stop();
-            this.originalLog("🌐 Web Dashboard has been stopped.");
+            this.webServer.broadcastLog({ time, msg: cleanMsg, type, raw });
+            this.webServer.broadcastState({
+                queueCount: this.manager.state.queueCount,
+                lastSchedule: this.manager.state.lastSchedule
+            });
         }
+    }
 
-        console.log("\n============================================");
-        console.log("📺 Dashboard 已關閉 (Visual Interface Detached)");
-        console.log("🤖 Golem v9.0 仍在背景執行中...");
-        console.log("============================================\n");
+    _handleError(args) {
+        if (this.manager.state.isDetached) return;
+        const msg = args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ');
+        this.view.log('error', `{red-fg}[錯誤] ${msg}{/red-fg}`);
+        if (this.webServer) {
+            this.webServer.broadcastLog({ time: new Date().toLocaleTimeString(), msg, type: 'error' });
+        }
     }
 
     startMonitoring() {
         this.timer = setInterval(() => {
-            if (this.isDetached) return clearInterval(this.timer);
+            if (this.manager.state.isDetached) return clearInterval(this.timer);
 
-            // CPU/Mem 模擬數據 (或真實數據)
             const memUsage = process.memoryUsage().heapUsed / 1024 / 1024;
-            this.memData.y.shift();
-            this.memData.y.push(memUsage);
-            this.cpuLine.setData([this.memData]);
+            const metricsData = this.manager.updateMetrics(memUsage);
+            this.view.updateMetrics(metricsData);
 
             const mode = process.env.GOLEM_MEMORY_MODE || 'Browser';
             const uptime = Math.floor(process.uptime());
             const hours = Math.floor(uptime / 3600);
             const minutes = Math.floor((uptime % 3600) / 60);
+            const uptimeStr = `${hours}h ${minutes}m`;
 
-            // Web Socket Heartbeat
+            this.view.updateStatus(this.manager.getSystemStatus(mode, uptimeStr));
+
             if (this.webServer) {
-                this.webServer.broadcastHeartbeat({
-                    memUsage,
-                    uptime: `${hours}h ${minutes}m`,
-                    cpu: 0 // Placeholder
-                });
+                this.webServer.broadcastHeartbeat({ memUsage, uptime: uptimeStr, cpu: 0 });
             }
-
-            // 狀態面板更新 (v9.0 特有狀態)
-            this.statusBox.setMarkdown(`
-# 核心狀態 (v9.0)
-- **模式**: ${mode}
-- **架構**: Multi-Agent
-- **運行**: ${hours}h ${minutes}m
-
-# System Modules
-- **Chronos**: Online
-- **Agents**: Ready
-- **狀態**: 🟢 Online
-`);
-            this.screen.render();
         }, 1000);
+    }
+
+    detach() {
+        this.manager.state.isDetached = true;
+        ConsoleInterceptor.restore();
+        this.view.destroy();
+
+        if (this.webServer) {
+            this.webServer.stop();
+            ConsoleInterceptor.originalLog("🌐 Web Dashboard has been stopped.");
+        }
+
+        process.stdout.write("\n============================================\n");
+        process.stdout.write("📺 Dashboard 已關閉 (Visual Interface Detached)\n");
+        process.stdout.write("🤖 Golem v9.0 仍在背景執行中...\n");
+        process.stdout.write("============================================\n\n");
     }
 
     setContext(brain, memory) {

--- a/src/managers/DashboardManager.js
+++ b/src/managers/DashboardManager.js
@@ -1,0 +1,70 @@
+/**
+ * 🧠 DashboardManager - 負責 Dashboard 的業務邏輯與狀態管理
+ */
+class DashboardManager {
+    constructor() {
+        this.state = {
+            queueCount: 0,
+            lastSchedule: "無排程",
+            isDetached: false
+        };
+        // 4. 資料初始化
+        this.metrics = {
+            title: 'Memory (MB)',
+            x: Array(60).fill(0).map((_, i) => i.toString()),
+            y: Array(60).fill(0)
+        };
+    }
+
+    /**
+     * 解析日誌內容並決定分流類型
+     */
+    dispatchLog(args) {
+        const msg = args.map(a => typeof a === 'object' ? JSON.stringify(a) : a).join(' ');
+        const cleanMsg = msg.replace(/\u001b\[.*?m/g, '').replace(/\{.*?\}/g, '');
+
+        // 分流邏輯 - 根據日誌關鍵字決定顯示區域
+        let type = 'general';
+        if (cleanMsg.includes('[Chronos]') || cleanMsg.includes('排程') || cleanMsg.includes('TimeWatcher')) {
+            type = 'chronos';
+            if (cleanMsg.includes('新增排程')) {
+                // 解析排程內容
+                this.state.lastSchedule = (cleanMsg.split('新增排程:')[1] || "更新中...").trim();
+            }
+        } else if (cleanMsg.includes('[MultiAgent]') || cleanMsg.includes('[InteractiveMultiAgent]')) {
+            // v9.0 新增：捕捉 MultiAgent 會議紀錄
+            type = 'agent';
+        } else if (cleanMsg.includes('[Queue]') || cleanMsg.includes('隊列')) {
+            // 處理隊列流量監控
+            type = 'queue';
+            if (cleanMsg.includes('加入隊列')) this.state.queueCount++;
+            if (cleanMsg.includes('開始處理')) this.state.queueCount = Math.max(0, this.state.queueCount - 1);
+        }
+
+        return { type, msg, cleanMsg, raw: msg };
+    }
+
+    updateMetrics(value) {
+        this.metrics.y.shift();
+        this.metrics.y.push(value);
+        return [this.metrics];
+    }
+
+    getSystemStatus(mode, uptime) {
+        return `
+# 核心狀態 (v9.0)
+- **模式**: ${mode}
+- **架構**: Multi-Agent
+- **運行**: ${uptime}
+
+# System Modules
+- **Chronos**: Online
+- **Agents**: Ready
+- **狀態**: 🟢 Online
+- **隊列**: ${this.state.queueCount}
+- **排程**: ${this.state.lastSchedule}
+`;
+    }
+}
+
+module.exports = DashboardManager;

--- a/src/utils/ConsoleInterceptor.js
+++ b/src/utils/ConsoleInterceptor.js
@@ -1,0 +1,41 @@
+/**
+ * 🛡️ ConsoleInterceptor - 集中處理控制台攔截邏輯
+ */
+class ConsoleInterceptor {
+    constructor() {
+        // 1. 保存原始的 Console 方法 (備份以利後續還原)
+        this.originalLog = console.log;
+        this.originalError = console.error;
+        this.onLog = null;
+        this.onError = null;
+    }
+
+    /**
+     * 啟動攔截器
+     * @param {Object} callbacks - 包含 onLog 與 onError 的回呼函式
+     */
+    hijack(callbacks = {}) {
+        this.onLog = callbacks.onLog;
+        this.onError = callbacks.onError;
+
+        console.log = (...args) => {
+            this.originalLog.apply(console, args); // 保持原輸出到終端
+            if (this.onLog) this.onLog(args);
+        };
+
+        console.error = (...args) => {
+            this.originalError.apply(console, args);
+            if (this.onError) this.onError(args);
+        };
+    }
+
+    /**
+     * 還原原始的 Console 方法 (退出系統時調用)
+     */
+    restore() {
+        console.log = this.originalLog;
+        console.error = this.originalError;
+    }
+}
+
+module.exports = new ConsoleInterceptor();

--- a/src/views/TerminalView.js
+++ b/src/views/TerminalView.js
@@ -1,0 +1,101 @@
+const blessed = require('blessed');
+const contrib = require('blessed-contrib');
+
+/**
+ * 📺 TerminalView - 純粹的 Terminal UI 渲染層
+ */
+class TerminalView {
+    constructor(options = {}) {
+        this.screen = blessed.screen({
+            smartCSR: true,
+            title: options.title || '🦞 Golem Control Console',
+            fullUnicode: true
+        });
+
+        // 建立網格 (12x12)
+        this.grid = new contrib.grid({ rows: 12, cols: 12, screen: this.screen });
+        this._initWidgets();
+
+        this.screen.key(['escape', 'q', 'C-c'], () => {
+            if (options.onExit) options.onExit();
+        });
+    }
+
+    // --- 介面元件佈局 ---
+    _initWidgets() {
+        // [左上] 系統心跳 (CPU/RAM)
+        this.cpuLine = this.grid.set(0, 0, 4, 8, contrib.line, {
+            style: { line: "yellow", text: "green", baseline: "black" },
+            label: '⚡ 系統核心 (System Core)',
+            showLegend: true
+        });
+
+        // [右上] 狀態概覽 (Status)
+        this.statusBox = this.grid.set(0, 8, 4, 4, contrib.markdown, {
+            label: '📊 狀態 (Status)',
+            tags: true,
+            style: { border: { fg: 'cyan' } }
+        });
+
+        // [中層] 時序雷達 (Chronos Log) - 專門顯示排程與時間相關資訊
+        this.chronosLog = this.grid.set(4, 0, 3, 6, contrib.log, {
+            fg: "green",
+            selectedFg: "green",
+            label: '⏰ 時序雷達 (Chronos Radar)'
+        });
+
+        // [中層] 隊列監控 (Queue Log) - 顯示對話進出與 Agent 會議
+        this.queueLog = this.grid.set(4, 6, 3, 6, contrib.log, {
+            fg: "magenta",
+            selectedFg: "magenta",
+            label: '🚦 隊列交通 (Traffic & Agents)'
+        });
+
+        // [底層] 全域日誌 (Global Log)
+        this.logBox = this.grid.set(7, 0, 5, 12, contrib.log, {
+            fg: "white",
+            selectedFg: "white",
+            label: '📝 核心日誌 (Neuro-Link Stream)'
+        });
+    }
+
+    render() {
+        this.screen.render();
+    }
+
+    destroy() {
+        this.screen.destroy();
+    }
+
+    /**
+     * 向指定區域發送日誌
+     * @param {string} type - 日誌類型 (chronos|queue|agent|general)
+     * @param {string} message - 格式化後的訊息
+     */
+    log(type, message) {
+        switch (type) {
+            case 'chronos':
+                if (this.chronosLog) this.chronosLog.log(message);
+                break;
+            case 'queue':
+            case 'agent':
+                if (this.queueLog) this.queueLog.log(message);
+                break;
+            default:
+                if (this.logBox) this.logBox.log(message);
+        }
+        this.render();
+    }
+
+    updateStatus(markdown) {
+        this.statusBox.setMarkdown(markdown);
+        this.render();
+    }
+
+    updateMetrics(data) {
+        this.cpuLine.setData(data);
+        this.render();
+    }
+}
+
+module.exports = TerminalView;


### PR DESCRIPTION
## 說明 (Description)

### 🧐 變更背景 (Context)
隨着 Golem 進入 v9.0 MultiAgent 時代，原有的 [dashboard.js](file:///Users/alan/code/contribute/tmp/dashboard.js) 承載了過多的職責（UI 渲染、業務邏輯、控制台攔截），形成了典型的「大雜燴」代碼（God Class）。為了提升系統的可擴展性並降低維護成本，我們對其進行了「老屋翻修」，將其拆解為具備單一職責的模組。

### 🛠️ 重大變更 (Changes)
本次重構將 [dashboard.js](file:///Users/alan/code/contribute/tmp/dashboard.js) 的功能完整拆分為以下三個核心組件：

1.  **[New] [src/views/TerminalView.js](file:///Users/alan/code/contribute/tmp/src/views/TerminalView.js)**: 
    - 專注於 **視圖層 (View)**。
    - 封裝 `blessed` 與 `blessed-contrib` 的佈局邏輯。
    - 提供乾淨的 [log()](file:///Users/alan/code/contribute/tmp/src/views/TerminalView.js#70-89), [updateStatus()](file:///Users/alan/code/contribute/tmp/src/views/TerminalView.js#90-94), [updateMetrics()](file:///Users/alan/code/contribute/tmp/src/managers/DashboardManager.js#47-52) 介面。
2.  **[New] [src/managers/DashboardManager.js](file:///Users/alan/code/contribute/tmp/src/managers/DashboardManager.js)**:
    - 專注於 **邏輯/狀態層 (Manager)**。
    - 負責解析日誌類型（Chronos, Agent, Queue）、計算記憶體指標及追蹤系統狀態。
    - 與 UI 框架解耦，未來可輕易移植或進行單元測試。
3.  **[New] [src/utils/ConsoleInterceptor.js](file:///Users/alan/code/contribute/tmp/src/utils/ConsoleInterceptor.js)**:
    - 專注於 **基礎工具 (Utility)**。
    - 集中管理 `console.log` 的攔截（Hijack）與還原（Restore）邏輯，避免散落在業務代碼中。

### ✨ 帶來的效益 (Benefits)
- **遵循 SRP (單一職責原則)**：每個檔案僅負責一件事，代碼更易讀、易懂。
- **提升測試性**：現在可以單獨針對 [DashboardManager](file:///Users/alan/code/contribute/tmp/src/managers/DashboardManager.js#4-69) 的日誌分流邏輯撰寫測試，無需啟動終端介面。
- **架構擴展性**：未來若要將介面從終端轉換為 React/Web 介面，只需更換 View 層即可。

---

### 🧪 驗證計畫 (Verification)
- [x] 啟動程式確認終端介面顯示正常。
- [x] 確認 MultiAgent (cyan-fg) 與 Chronos (yellow-fg) 日誌能正確分流至對應區塊。
- [x] 測試 Web Dashboard 廣播功能是否依然運作正常。
- [x] 確保按下 `q` 或 `Ctrl+C` 時，攔截器能正確還原並顯示關閉訊息。
