### PR TITLE
feat: 新增 Web Dashboard 系統重新啟動 (Reload) 功能

### DIFF
--- a/web-dashboard/server.js
+++ b/web-dashboard/server.js
@@ -96,6 +96,22 @@ class WebServer {
             }
         });
 
+        this.app.post('/api/system/reload', (req, res) => {
+            console.log("🔄 [WebServer] Received reload request. Restarting system...");
+            res.json({ success: true, message: "System is restarting..." });
+
+            // Small delay to ensure the response is sent before the process exits
+            setTimeout(() => {
+                const { spawn } = require('child_process');
+                const subprocess = spawn(process.argv[0], process.argv.slice(1), {
+                    detached: true,
+                    stdio: 'ignore'
+                });
+                subprocess.unref();
+                process.exit(0);
+            }, 1000);
+        });
+
         // Socket.io connection handler
         this.io.on('connection', (socket) => {
             // Send initial state upon connection


### PR DESCRIPTION
### 🎯 目的
為了解決 Golem 在長時間執行或發生假性卡死時需要手動重啟的問題，本次更新在 Web Dashboard 介面中整合了「一鍵重啟」功能，讓使用者能直接透過瀏覽器物理重建 Node.js 進程。
### 🛠️ 變更內容
#### 1. 後端 (Backend) - web-dashboard/server.js
- 新增 `POST /api/system/reload` API 接口。
- 使用 `child_process.spawn` 實作進程克隆 (Clone) 邏輯。
- 透過 `detached: true` 與 `process.exit(0)` 確保舊線程安全結束並啟動全新實體。
#### 2. 前端 (Frontend) - web-dashboard/src/app/dashboard/page.tsx
- 在「System Status」卡片中配置 UI 區塊，新增「重新啟動 Golem」按鈕。
- 整合 `lucide-react` 的 `RefreshCcw` 圖標，並加入重啟時的旋轉動畫。
- 實作 `isReloading` 狀態管理與 confirm 確認對話框，防止使用者誤觸。
### 🧪 驗證方式
1. 啟動 `npm run dashboard`。
2. 開啟瀏覽器進入 Dashboard 頁面。
3. 點擊「重新啟動 Golem」按鈕並確認。
4. 觀察終端機是否顯示 `🛡️ [Flood Guard]` 的重啟日誌，並確認網頁在 3 秒後自動重整恢復連線。
### ⚠️ 注意事項
- 重啟過程會導致後端短暫斷線，Dashboard 會出現連線中斷提示屬正常現象。
- 若系統處於同步死循環 (Main Thread Block) 狀態，此接口可能無法反應。