### PR TITLE
feat: 實作 Model Context Protocol (MCP) 客戶端與全方位 Dashboard 管理介面

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ graph TD
 | 文件 | 說明 |
 |------|------|
 | [🤖 編碼代理指南](docs/AGENTS.md) | **[重要]** 供 AI 助理或開發者參考的程式碼維護與架構規範 |
+| [🔌 MCP 使用與開發指南](docs/MCP-使用與開發指南.md) | **[最新]** 如何安裝、配置與調用 MCP Server (含 Hacker News 範例) |
 | [🧠 記憶系統架構說明](docs/記憶系統架構說明.md) | 金字塔壓縮原理與存放路徑解析 |
 | [🖥️ Web Dashboard 使用說明](docs/Web-Dashboard-使用說明.md) | Web UI 各個分頁的延伸細節 |
 | [🛠️ 開發者實作指南](docs/開發者實作指南.md) | 如何實作新的 Skill 與 Golem Protocol 格式規範 |

--- a/data/mcp-servers.json
+++ b/data/mcp-servers.json
@@ -1,0 +1,131 @@
+[
+  {
+    "name": "chrome-devtools",
+    "command": "npx",
+    "args": [
+      "-y",
+      "chrome-devtools-mcp@latest"
+    ],
+    "env": {},
+    "enabled": false,
+    "description": "Chrome DevTools MCP — 網頁除錯、效能分析、DOM 操作、Lighthouse",
+    "cachedTools": [
+      {
+        "name": "click",
+        "description": "Clicks on the provided element"
+      },
+      {
+        "name": "close_page",
+        "description": "Closes the page by its index. The last open page cannot be closed."
+      },
+      {
+        "name": "drag",
+        "description": "Drag an element onto another element"
+      },
+      {
+        "name": "emulate",
+        "description": "Emulates various features on the selected page."
+      },
+      {
+        "name": "evaluate_script",
+        "description": "Evaluate a JavaScript function inside the currently selected page. Returns the response as JSON,\nso returned values have to be JSON-serializable."
+      },
+      {
+        "name": "fill",
+        "description": "Type text into a input, text area or select an option from a <select> element."
+      },
+      {
+        "name": "fill_form",
+        "description": "Fill out multiple form elements at once"
+      },
+      {
+        "name": "get_console_message",
+        "description": "Gets a console message by its ID. You can get all messages by calling list_console_messages."
+      },
+      {
+        "name": "get_network_request",
+        "description": "Gets a network request by an optional reqid, if omitted returns the currently selected request in the DevTools Network panel."
+      },
+      {
+        "name": "handle_dialog",
+        "description": "If a browser dialog was opened, use this command to handle it"
+      },
+      {
+        "name": "hover",
+        "description": "Hover over the provided element"
+      },
+      {
+        "name": "lighthouse_audit",
+        "description": "Get Lighthouse score and reports for accessibility, SEO and best practices. This excludes performance. For performance audits, run performance_start_trace"
+      },
+      {
+        "name": "list_console_messages",
+        "description": "List all console messages for the currently selected page since the last navigation."
+      },
+      {
+        "name": "list_network_requests",
+        "description": "List all requests for the currently selected page since the last navigation."
+      },
+      {
+        "name": "list_pages",
+        "description": "Get a list of pages  open in the browser."
+      },
+      {
+        "name": "navigate_page",
+        "description": "Go to a URL, or back, forward, or reload. Use project URL if not specified otherwise."
+      },
+      {
+        "name": "new_page",
+        "description": "Open a new tab and load a URL. Use project URL if not specified otherwise."
+      },
+      {
+        "name": "performance_analyze_insight",
+        "description": "Provides more detailed information on a specific Performance Insight of an insight set that was highlighted in the results of a trace recording."
+      },
+      {
+        "name": "performance_start_trace",
+        "description": "Start a performance trace on the selected webpage. Use to find frontend performance issues, Core Web Vitals (LCP, INP, CLS), and improve page load speed."
+      },
+      {
+        "name": "performance_stop_trace",
+        "description": "Stop the active performance trace recording on the selected webpage."
+      },
+      {
+        "name": "press_key",
+        "description": "Press a key or key combination. Use this when other input methods like fill() cannot be used (e.g., keyboard shortcuts, navigation keys, or special key combinations)."
+      },
+      {
+        "name": "resize_page",
+        "description": "Resizes the selected page's window so that the page has specified dimension"
+      },
+      {
+        "name": "select_page",
+        "description": "Select a page as a context for future tool calls."
+      },
+      {
+        "name": "take_memory_snapshot",
+        "description": "Capture a memory heapsnapshot of the currently selected page to memory leak debugging"
+      },
+      {
+        "name": "take_screenshot",
+        "description": "Take a screenshot of the page or element."
+      },
+      {
+        "name": "take_snapshot",
+        "description": "Take a text snapshot of the currently selected page based on the a11y tree. The snapshot lists page elements along with a unique\nidentifier (uid). Always use the latest snapshot. Prefer taking a snapshot over taking a screenshot. The snapshot indicates the element selected\nin the DevTools Elements panel (if any)."
+      },
+      {
+        "name": "type_text",
+        "description": "Type text using keyboard into a previously focused input"
+      },
+      {
+        "name": "upload_file",
+        "description": "Upload a file through a provided element."
+      },
+      {
+        "name": "wait_for",
+        "description": "Wait for the specified text to appear on the selected page."
+      }
+    ]
+  }
+]

--- a/docs/MCP-Guide.en.md
+++ b/docs/MCP-Guide.en.md
@@ -1,0 +1,85 @@
+# MCP (Model Context Protocol) Usage and Development Guide
+
+The Model Context Protocol (MCP) is an open standard that enables AI models to interact securely and seamlessly with local or remote tools and data sources.
+
+In Project Golem, **Golem acts as the MCP Client**, while various tools (such as Hacker News scrapers or Chrome DevTools controllers) act as **MCP Servers**. This architecture provides Golem with infinite extensibility.
+
+---
+
+## 🚀 Quick Start: Using Hacker News MCP as an Example
+
+This section will guide you through installing and integrating [hn-server](https://github.com/pskill9/hn-server) into Golem.
+
+### 1. Compile the MCP Server locally
+First, clone the MCP Server and build it:
+
+```bash
+# We recommend placing these in a 'vendors' folder within the project directory
+git clone https://github.com/pskill9/hn-server
+cd hn-server
+
+# Install dependencies and build
+npm install
+npm run build
+```
+
+Once built, the core entry point is usually located at `build/index.js` or `dist/index.js`.
+
+### 2. Add the Server in Web Dashboard
+Open Golem's Web Dashboard and click on **"MCP Tools"** in the sidebar.
+
+1. Click **"Add Server"**.
+2. Fill in the following fields:
+   - **Name**: `hacker-news` (Lowercase recommended; this is the ID used by the AI)
+   - **Command**: `node`
+   - **Arguments**: Enter the **absolute path** to the built file, for example:
+     `["/Users/yourname/project-golem/hn-server/build/index.js"]`
+   - **Description**: `Hacker News real-time data fetching tool`
+3. Click **"Save"**.
+
+### 3. Test Connection
+Locate `hacker-news` in the server list and click the **"Test Connection"** icon (lightning bolt).
+If it displays "Found X tools," Golem has successfully established a JSON-RPC connection with the server.
+
+### 4. Interact with Golem
+After restarting Golem, you can give it direct instructions:
+> "Get me the top 5 stories from Hacker News"
+
+Golem will automatically recognize the prompt and issue an Action like this:
+```json
+[ACTION]
+{
+  "action": "mcp_call",
+  "server": "hacker-news",
+  "tool": "get_stories",
+  "parameters": {
+    "type": "top",
+    "limit": 5
+  }
+}
+[/ACTION]
+```
+
+---
+
+## 🛠️ Management Features
+
+### Live Logs
+The log panel at the bottom of the MCP page displays real-time details:
+- Call timestamps and duration
+- Sent parameters
+- Raw server responses
+- Error messages (if any)
+
+### Tool Inspector
+Clicking on a server in the list shows all available tools and their parameter definitions (JSON Schema). Golem's brain reads these definitions at startup to ensure accurate tool invocation.
+
+---
+
+## 💡 Best Practices
+
+1. **Path Management**: Always use **absolute paths** for configuration. Node.js does not automatically expand `~` in subprocess commands.
+2. **Lazy Loading**: Golem's MCP Manager uses lazy loading; server processes are started only when needed for a tool call or when viewed in the dashboard.
+3. **Troubleshooting**: If the AI cannot find a tool, ensure the server is **Enabled** in the dashboard and that the connection test succeeds.
+
+For more official MCP server examples, see: [Model Context Protocol GitHub](https://github.com/modelcontextprotocol/servers)

--- a/docs/MCP-使用與開發指南.md
+++ b/docs/MCP-使用與開發指南.md
@@ -1,0 +1,85 @@
+# MCP (Model Context Protocol) 使用與開發指南
+
+Model Context Protocol (MCP) 是一個開放標準，能讓 AI 模型安全、無縫地與本地或遠端工具、資料源進行互動。
+
+在 Project Golem 中，**Golem 作為 MCP Client (客戶端)**，而各類工具（如 Hacker News 抓取器、Chrome DevTools 控制器）則作為 **MCP Server (伺服器端)**。這使得 Golem 具備了無限擴展的能力。
+
+---
+
+## 🚀 快速上手：以 Hacker News MCP 為例
+
+本節將指導你如何安裝並整合 [hn-server](https://github.com/pskill9/hn-server) 到 Golem 中。
+
+### 1. 本地編譯 MCP Server
+首先，你需要將 MCP Server 下載到本地並完成編譯：
+
+```bash
+# 建議統一放在專案目錄下的 vendors (或其他你喜歡的地方)
+git clone https://github.com/pskill9/hn-server
+cd hn-server
+
+# 安裝依賴並編譯
+npm install
+npm run build
+```
+
+編譯完成後，核心檔案路徑通常位於 `dist/index.js` 或 `build/index.js`。
+
+### 2. 在 Web Dashboard 中新增 Server
+開啟 Golem 的 Web Dashboard，點擊左側導航欄的 **「MCP 工具」**。
+
+1. 點擊 **「新增 Server」**。
+2. 填寫以下欄位：
+   - **名稱**：`hacker-news` (建議使用英文小寫，這也是 AI 調用時的識別碼)
+   - **指令**：`node`
+   - **參數**：填入編譯後檔案的 **絕對路徑**，例如：
+     `["/Users/yourname/project-golem/hn-server/build/index.js"]`
+   - **描述**：`Hacker News 實時數據抓取工具`
+3. 點擊 **「儲存」**。
+
+### 3. 測試連線
+在伺服器列表中找到 `hacker-news`，點擊右側的 **「測試連線」** (高壓電圖示)。
+若顯示「發現 X 個工具」，則表示 Golem 已成功與該 Server 建立 JSON-RPC 連線。
+
+### 4. 與 Golem 對話
+重啟 Golem 後，你就可以直接下達指令：
+> 「幫我抓 Hacker News 目前前 5 名的頭條」
+
+Golem 會自動識別並發出如下 Action：
+```json
+[ACTION]
+{
+  "action": "mcp_call",
+  "server": "hacker-news",
+  "tool": "get_stories",
+  "parameters": {
+    "type": "top",
+    "limit": 5
+  }
+}
+[/ACTION]
+```
+
+---
+
+## 🛠️ 管理功能說明
+
+### 實時日誌 (Live Logs)
+在 MCP 頁面下方設有日誌面板，會實時顯示：
+- 調用的時間與耗時
+- 傳送的參數
+- Server 回傳的原始資料
+- 錯誤訊息（若調用失敗）
+
+### 工具檢查 (Tool Inspector)
+點擊清單中的 Server，右側會顯示該 Server 提供的所有可用工具清單及其參數定義 (JSON Schema)。Golem 的大腦也會在啟動時自動讀取這些清單，確保能準確調用。
+
+---
+
+## 💡 開發建議
+
+1. **路徑問題**：在設定參數時，請務必使用 **絕對路徑**。Node.js 在執行子進程時不會自動展開 `~`。
+2. **防震機制**：Golem 的 MCP Manager 具備 Lazy-load 機制，只有在第一次需要調用或開啟 Dashboard 時才會啟動 Server 進程。
+3. **錯誤排查**：若 AI 找不到工具，請檢查 Dashboard 中的 Server 是否處於 **Enabled** 狀態，並確認測試連線是否成功。
+
+更多官方 MCP Server 範例，請參考：[Model Context Protocol GitHub](https://github.com/modelcontextprotocol/servers)

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -201,9 +201,10 @@ To keep this page concise, more in-depth technical details have been moved to de
 
 | Document | Description |
 |------|------|
+| [🔌 MCP Usage & Development Guide](MCP-Guide.en.md) | **[New]** How to install, configure, and call MCP Servers (includes Hacker News example) |
 | [🤖 AI Agent Guide](AGENTS.en.md) | **[Important]** Guidelines for AI assistants and developers on code maintenance |
 | [🧠 Memory System Architecture](記憶系統架構說明.md) | Pyramid compression principles and storage path analysis |
-| [🖥️ Web Dashboard Guide](Web-Dashboard-使用說明.md) | Extended details for each tab in the Web UI |
+| [🖥️ Web Dashboard Guide](Web-Dashboard-Guide.en.md) | Extended details for each tab in the Web UI |
 | [🛠️ Developer Implementation Guide](開發者實作指南.md) | How to implement new Skills and Golem Protocol specifications |
 | [🎮 Command Reference List](golem指令說明一覽表.md) | Quick reference for Telegram / Discord commands |
 | [🔑 Getting Robot Tokens](如何獲取TG或DC的Token及開啟權限.md) | How to set up your external communication platforms |

--- a/docs/Web-Dashboard-Guide.en.md
+++ b/docs/Web-Dashboard-Guide.en.md
@@ -1,0 +1,119 @@
+# 🖥️ Project Golem Web Dashboard Guide
+
+> Last Updated: 2026-03-20  
+> Tech Stack: Next.js + Tailwind CSS + Socket.io
+
+## 1. How to Start
+
+```bash
+# Development Mode (with Hot Reload)
+cd web-dashboard
+npm run dev        # Default: http://localhost:3000
+
+# Production Mode (Static Export)
+npm run build
+# Served by the project root's server.js
+node server.js     # Default: http://localhost:3000
+```
+
+> The Dashboard and the main Bot (`index.js`) are **independent processes**. The Dashboard communicates with the Bot in real-time via Socket.io.
+
+---
+
+## 2. Page Overview
+
+### 🎛️ Tactical Console (`/dashboard`)
+The home view providing an overview of:
+- Active Golem status
+- Dynamic context imagery (switches based on active skills/multi-agent scenarios)
+- Quick action shortcuts
+
+---
+
+### 💻 Web Terminal (`/dashboard/terminal`)
+**Communicate directly with Golem** and observe real-time responses. This is the web equivalent of the admin Telegram terminal.
+
+Features:
+- Real-time conversation input
+- Full Golem output display (including Action execution logs)
+- Instance switching support
+
+---
+
+### 📚 Skill Manager (`/dashboard/skills`)
+The central hub for managing Golem's capabilities:
+- **List Skills**: View descriptions of CORE and USER skills.
+- **Toggle Skills**: Enable or disable specific functions.
+- **Inject Skills**: Reload skill books into Gemini (equivalent to `/reload`).
+
+---
+
+### 👥 Agent Room (`/dashboard/agents`)
+**The visual interface for the InteractiveMultiAgent system**.
+- Configure the participating agent list (Name, Role, Personality).
+- Set the maximum number of discussion rounds.
+- Start roundtable discussions.
+- Real-time display of agent dialogue and consensus summaries.
+
+---
+
+### 🔌 MCP Tools (`/dashboard/mcp`) 🆕
+**Model Context Protocol Management Center** for integrating external tools and data sources.
+- **Server Management**: Add, edit, or delete MCP Servers (stdio transport).
+- **Connection Test**: One-click test for server connectivity.
+- **Tool Inspector**: Real-time display of tool names and parameter schemas.
+- **Live Logs**: Visualize JSON-RPC traffic for debugging.
+
+---
+
+### 🏢 Automation Center (`/dashboard/office`)
+Manages **automated tasks**, including schedule checks, system introspection, and periodic maintenance logs.
+
+---
+
+### 🧠 Memory Core (`/dashboard/memory`)
+The management interface for the vector memory store:
+- **Browse Memory**: List all stored long-term memory entries.
+- **Semantic Search**: Test the semantic search engine with keywords.
+- **Delete/Reset**: Remove specific entries or clear the entire memory store.
+
+---
+
+### ⚙️ System Settings (`/dashboard/settings`)
+System configuration and status monitoring:
+- **Golem List**: View all instances and their health status.
+- **Env Variables**: View and modify `.env` settings.
+- **Log Management**: Trigger log compression and view history.
+- **System Upgrade**: Trigger hot-updates from GitHub.
+
+---
+
+## 3. Backend APIs (server.js)
+
+| Route | Description |
+|------|------|
+| `GET /api/golems` | Get Golem list |
+| `GET /api/status/:id` | Get status of a specific Golem |
+| `POST /api/message` | Send a message to Golem |
+| `GET /api/mcp/servers` | Get MCP Server list |
+| `POST /api/mcp/servers/:name/test` | Test specific MCP connection |
+| `GET /api/mcp/logs` | Read MCP call logs |
+| `Socket.IO` | Real-time push for responses, system events, and MCP logs |
+
+---
+
+## 4. Multi-Agent Workflow
+
+```
+User Configuration:
+  Task description, Agent roles, Max rounds
+        ↓
+InteractiveMultiAgent.startConversation()
+        ↓
+  Round 1: Agent A speaks → Agent B speaks → Agent C speaks
+  Round 2: Each agent responds to others + User can intervene via @mentions
+  ...
+  Consensus detection → Early termination
+        ↓
+_generateSummary() → Final consensus summary sent to user
+```

--- a/docs/Web-Dashboard-使用說明.md
+++ b/docs/Web-Dashboard-使用說明.md
@@ -67,6 +67,18 @@ node server.js     # 預設：http://localhost:3000
 
 ---
 
+### 🔌 MCP 工具 (`/dashboard/mcp`) 🆕
+
+**Model Context Protocol 管理中心**，用於整合外部工具與資料源。
+
+功能：
+- **Server 管理**：新增/編輯/刪除 MCP Server（支援 stdio 傳輸）。
+- **連線測試**：一鍵測試 Golem 與 Server 的連線狀態。
+- **工具查閱**：即時顯示各個 Server 提供的工具名稱與參數定義。
+- **實時日誌**：觀察 JSON-RPC 往返細項，除錯必備。
+
+---
+
 ### 🏢 自動化中心 (`/dashboard/office`)
 
 管理系統的**自動化任務**，包含排程檢查、系統自省與定期維護日誌。
@@ -126,7 +138,10 @@ Dashboard 後端由 `web-dashboard/server.js` 提供，主要功能：
 | `POST /api/message` | 向 Golem 傳送訊息 |
 | `GET /api/memory/:id` | 讀取記憶清單 |
 | `POST /api/skills/reload` | 重新注入技能書 |
-| `Socket.IO` | 即時推送 Golem 回應與系統事件 |
+| `GET /api/mcp/servers` | 取得 MCP Server 列表 |
+| `POST /api/mcp/test/:name` | 測試指定 MCP 連線 |
+| `GET /api/mcp/logs` | 讀取 MCP 調用日誌 |
+| `Socket.IO` | 即時推送 Golem 回應、系統事件、MCP 日誌 |
 
 ---
 

--- a/src/core/action_handlers/SkillHandler.js
+++ b/src/core/action_handlers/SkillHandler.js
@@ -1,7 +1,43 @@
 const skillManager = require('../../managers/SkillManager');
+const MCPManager   = require('../../mcp/MCPManager');
 
 class SkillHandler {
     static async execute(ctx, act, brain) {
+        // ─── MCP Tool Call ─────────────────────────────────────────────
+        if (act.action === 'mcp_call') {
+            const { server, tool, parameters = {} } = act;
+            if (!server || !tool) {
+                await ctx.reply(`❌ mcp_call 缺少必要欄位 server 或 tool`);
+                return true;
+            }
+            await ctx.reply(`🔌 [MCP] 調用 **${server}** → **${tool}**...`);
+            try {
+                const mcpManager = MCPManager.getInstance();
+                await mcpManager.load();   // 確保 servers 已連線（load 內部有冪等保護）
+                const result     = await mcpManager.callTool(server, tool, parameters);
+
+                // 格式化結果
+                let displayResult = '';
+                if (result && result.content && Array.isArray(result.content)) {
+                    displayResult = result.content
+                        .map(c => c.type === 'text' ? c.text : JSON.stringify(c))
+                        .join('\n');
+                } else {
+                    displayResult = JSON.stringify(result, null, 2);
+                }
+
+                const MAX_LEN = 3800;
+                if (displayResult.length > MAX_LEN) {
+                    displayResult = displayResult.slice(0, MAX_LEN) + '\n...(已截斷)';
+                }
+                await ctx.reply(`✅ [MCP:${server}/${tool}]\n${displayResult}`);
+            } catch (e) {
+                await ctx.reply(`❌ [MCP] 執行錯誤: ${e.message}`);
+            }
+            return true;
+        }
+
+        // ─── Dynamic Skills ────────────────────────────────────────────
         const skillName = act.action;
         const dynamicSkill = skillManager.getSkill(skillName);
 

--- a/src/mcp/MCPClient.js
+++ b/src/mcp/MCPClient.js
@@ -1,0 +1,191 @@
+/**
+ * MCPClient.js — JSON-RPC 2.0 stdio transport MCP Client
+ *
+ * 透過 child_process.spawn 啟動本地 MCP Server，
+ * 實作 initialize handshake、tools/list、tools/call。
+ */
+
+const { spawn } = require('child_process');
+const { EventEmitter } = require('events');
+
+class MCPClient extends EventEmitter {
+    /**
+     * @param {Object} config
+     * @param {string} config.name        - Server 名稱
+     * @param {string} config.command     - 執行指令 (e.g. "codex", "npx")
+     * @param {string[]} config.args      - 指令參數
+     * @param {Object}  config.env        - 額外環境變數
+     * @param {number}  config.timeout    - 請求超時 ms (預設 30000)
+     */
+    constructor(config) {
+        super();
+        this.name    = config.name;
+        this.command = config.command;
+        this.args    = config.args || [];
+        this.env     = config.env  || {};
+        this.timeout = config.timeout || 30000;
+
+        this._process     = null;
+        this._pending     = new Map();   // id -> { resolve, reject, timer }
+        this._nextId      = 1;
+        this._buf         = '';
+        this._connected   = false;
+        this._capabilities = {};
+        this._tools        = [];
+    }
+
+    // ─── Public API ────────────────────────────────────────────────
+    async connect() {
+        if (this._connected) return;
+
+        return new Promise((resolve, reject) => {
+            const env = { ...process.env, ...this.env };
+
+            this._process = spawn(this.command, this.args, {
+                stdio: ['pipe', 'pipe', 'pipe'],
+                env
+            });
+
+            this._process.stdout.on('data', (chunk) => this._onData(chunk));
+            this._process.stderr.on('data', (chunk) => {
+                const msg = chunk.toString().trim();
+                if (msg) console.warn(`[MCPClient:${this.name}] stderr: ${msg}`);
+            });
+
+            this._process.on('error', (err) => {
+                console.error(`[MCPClient:${this.name}] Process error:`, err.message);
+                this._connected = false;
+                this.emit('error', err);
+                reject(err);
+            });
+
+            this._process.on('exit', (code, signal) => {
+                console.log(`[MCPClient:${this.name}] Process exited (code=${code}, signal=${signal})`);
+                this._connected = false;
+                this.emit('disconnected', { code, signal });
+                // Reject all pending requests
+                for (const [id, { reject: rej, timer }] of this._pending.entries()) {
+                    clearTimeout(timer);
+                    rej(new Error(`MCP Server "${this.name}" disconnected`));
+                    this._pending.delete(id);
+                }
+            });
+
+            // Wait for initialize to complete
+            this._initialize().then((caps) => {
+                this._capabilities = caps;
+                this._connected    = true;
+                this.emit('connected', { capabilities: caps });
+                resolve(caps);
+            }).catch(reject);
+        });
+    }
+
+    async disconnect() {
+        if (this._process) {
+            this._process.kill('SIGTERM');
+            this._process = null;
+        }
+        this._connected = false;
+    }
+
+    async listTools(forceRefresh = false) {
+        if (!this._connected) throw new Error(`MCP Server "${this.name}" not connected`);
+        if (this._tools.length > 0 && !forceRefresh) return this._tools;
+
+        const result = await this._rpc('tools/list', {});
+        this._tools  = result.tools || [];
+        return this._tools;
+    }
+
+    /**
+     * @param {string} toolName
+     * @param {Object} params
+     * @returns {Promise<Object>} tool result
+     */
+    async callTool(toolName, params = {}) {
+        if (!this._connected) throw new Error(`MCP Server "${this.name}" not connected`);
+
+        const result = await this._rpc('tools/call', {
+            name:      toolName,
+            arguments: params
+        });
+        return result;
+    }
+
+    get isConnected() { return this._connected; }
+    get tools()       { return this._tools; }
+    get capabilities(){ return this._capabilities; }
+
+    // ─── Private ───────────────────────────────────────────────────
+    async _initialize() {
+        const result = await this._rpc('initialize', {
+            protocolVersion: '2024-11-05',
+            capabilities:    { tools: {} },
+            clientInfo:      { name: 'project-golem', version: '1.0' }
+        });
+        // send initialized notification (no response expected)
+        this._notify('notifications/initialized', {});
+        return result.capabilities || {};
+    }
+
+    /** Send a JSON-RPC request, return promise that resolves with result */
+    _rpc(method, params) {
+        return new Promise((resolve, reject) => {
+            const id  = this._nextId++;
+            const msg = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n';
+
+            const timer = setTimeout(() => {
+                this._pending.delete(id);
+                reject(new Error(`MCP RPC timeout (${this.timeout}ms) for method "${method}"`));
+            }, this.timeout);
+
+            this._pending.set(id, { resolve, reject, timer });
+            this._process.stdin.write(msg);
+        });
+    }
+
+    /** Send a JSON-RPC notification (fire-and-forget) */
+    _notify(method, params) {
+        if (!this._process || !this._process.stdin.writable) return;
+        const msg = JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n';
+        this._process.stdin.write(msg);
+    }
+
+    _onData(chunk) {
+        this._buf += chunk.toString();
+        const lines = this._buf.split('\n');
+        this._buf   = lines.pop(); // keep incomplete last line
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            try {
+                const msg = JSON.parse(trimmed);
+                this._handleMessage(msg);
+            } catch (e) {
+                // Some servers output non-JSON lines (debug info) — ignore
+            }
+        }
+    }
+
+    _handleMessage(msg) {
+        if (msg.id !== undefined && this._pending.has(msg.id)) {
+            const { resolve, reject, timer } = this._pending.get(msg.id);
+            clearTimeout(timer);
+            this._pending.delete(msg.id);
+
+            if (msg.error) {
+                reject(new Error(`MCP error [${msg.error.code}]: ${msg.error.message}`));
+            } else {
+                resolve(msg.result);
+            }
+        }
+        // Notifications from server (no id) — emit as event
+        else if (msg.method && msg.id === undefined) {
+            this.emit('notification', { method: msg.method, params: msg.params });
+        }
+    }
+}
+
+module.exports = MCPClient;

--- a/src/mcp/MCPManager.js
+++ b/src/mcp/MCPManager.js
@@ -1,0 +1,266 @@
+/**
+ * MCPManager.js — 多 MCP Server 生命週期管理器
+ *
+ * 持久化配置到 data/mcp-servers.json
+ * 提供 addServer / removeServer / callTool / listTools 等方法
+ * 每次 callTool 呼叫都會 emit 'mcpLog' 事件
+ */
+
+const fs    = require('fs');
+const path  = require('path');
+const { EventEmitter } = require('events');
+const MCPClient = require('./MCPClient');
+
+const CONFIG_PATH = path.resolve(process.cwd(), 'data', 'mcp-servers.json');
+const MAX_LOG     = 500;
+
+class MCPManager extends EventEmitter {
+    constructor() {
+        super();
+        this._clients = new Map();  // name -> MCPClient
+        this._configs = [];         // persisted server configs
+        this._logs    = [];         // recent call logs
+        this._loaded  = false;
+    }
+
+    // ─── Singleton ─────────────────────────────────────────────────
+    static getInstance() {
+        if (!MCPManager._instance) {
+            MCPManager._instance = new MCPManager();
+        }
+        return MCPManager._instance;
+    }
+
+    // ─── Init ──────────────────────────────────────────────────────
+    /** 載入配置並啟動所有啟用的 server */
+    async load() {
+        if (this._loaded) return;
+        this._configs = this._readConfig();
+        this._loaded  = true;
+
+        // Auto-connect enabled servers
+        const enabledServers = this._configs.filter(c => c.enabled !== false);
+        for (const cfg of enabledServers) {
+            try {
+                await this._startClient(cfg);
+            } catch (e) {
+                console.warn(`[MCPManager] Auto-connect failed for "${cfg.name}": ${e.message}`);
+            }
+        }
+        console.log(`[MCPManager] Loaded ${this._configs.length} servers, ${this._clients.size} connected.`);
+    }
+
+    // ─── Server CRUD ───────────────────────────────────────────────
+    async addServer(cfg) {
+        if (this._configs.find(c => c.name === cfg.name)) {
+            throw new Error(`MCP server "${cfg.name}" already exists`);
+        }
+        const entry = {
+            name:    cfg.name,
+            command: cfg.command,
+            args:    cfg.args    || [],
+            env:     cfg.env     || {},
+            enabled: cfg.enabled !== false,
+            description: cfg.description || ''
+        };
+        this._configs.push(entry);
+        this._saveConfig();
+
+        if (entry.enabled) {
+            await this._startClient(entry);
+        }
+        return entry;
+    }
+
+    async updateServer(name, updates) {
+        const idx = this._configs.findIndex(c => c.name === name);
+        if (idx === -1) throw new Error(`MCP server "${name}" not found`);
+
+        const entry = { ...this._configs[idx], ...updates, name };
+        this._configs[idx] = entry;
+        this._saveConfig();
+
+        // Restart client if running
+        await this._stopClient(name);
+        if (entry.enabled) {
+            await this._startClient(entry);
+        }
+        return entry;
+    }
+
+    async removeServer(name) {
+        await this._stopClient(name);
+        this._configs = this._configs.filter(c => c.name !== name);
+        this._saveConfig();
+    }
+
+    async toggleServer(name, enabled) {
+        const cfg = this._configs.find(c => c.name === name);
+        if (!cfg) throw new Error(`MCP server "${name}" not found`);
+
+        cfg.enabled = enabled;
+        this._saveConfig();
+
+        if (enabled) {
+            await this._startClient(cfg);
+        } else {
+            await this._stopClient(name);
+        }
+        return cfg;
+    }
+
+    // ─── Tool Operations ───────────────────────────────────────────
+    async listTools(serverName) {
+        const client = this._clients.get(serverName);
+        if (!client) throw new Error(`MCP server "${serverName}" not connected`);
+        return await client.listTools();
+    }
+
+    /**
+     * 呼叫 MCP 工具，自動記錄 Log
+     * @param {string} serverName
+     * @param {string} toolName
+     * @param {Object} params
+     * @returns {Promise<Object>}
+     */
+    async callTool(serverName, toolName, params = {}) {
+        const startTime = Date.now();
+        const client = this._clients.get(serverName);
+        if (!client) throw new Error(`MCP server "${serverName}" not connected`);
+
+        let success = true;
+        let result  = null;
+        let error   = null;
+
+        try {
+            result = await client.callTool(toolName, params);
+        } catch (e) {
+            success = false;
+            error   = e.message;
+            throw e;
+        } finally {
+            const duration = Date.now() - startTime;
+            const logEntry = {
+                time:       new Date().toISOString(),
+                server:     serverName,
+                tool:       toolName,
+                params:     params,
+                success,
+                result:     success ? result : null,
+                error:      success ? null : error,
+                durationMs: duration
+            };
+            this._appendLog(logEntry);
+            this.emit('mcpLog', logEntry);
+        }
+        return result;
+    }
+
+    /** 列出所有 server 配置（含連線狀態） */
+    getServers() {
+        return this._configs.map(cfg => ({
+            ...cfg,
+            connected: this._clients.has(cfg.name) && this._clients.get(cfg.name).isConnected
+        }));
+    }
+
+    getServer(name) {
+        const cfg = this._configs.find(c => c.name === name);
+        if (!cfg) return null;
+        return {
+            ...cfg,
+            connected: this._clients.has(name) && this._clients.get(name).isConnected
+        };
+    }
+
+    getLogs(limit = 100) {
+        return this._logs.slice(-limit);
+    }
+
+    /** 測試連線（嘗試 listTools，成功後斷線） */
+    async testServer(name) {
+        const cfg = this._configs.find(c => c.name === name);
+        if (!cfg) throw new Error(`MCP server "${name}" not found`);
+
+        const testClient = new MCPClient({ ...cfg, timeout: 10000 });
+        try {
+            await testClient.connect();
+            const tools = await testClient.listTools();
+            return { success: true, toolCount: tools.length, tools };
+        } finally {
+            await testClient.disconnect();
+        }
+    }
+
+    // ─── Private ───────────────────────────────────────────────────
+    async _startClient(cfg) {
+        // Stop existing client if any
+        await this._stopClient(cfg.name);
+
+        const client = new MCPClient(cfg);
+
+        client.on('disconnected', () => {
+            console.log(`[MCPManager] Server "${cfg.name}" disconnected.`);
+            this._clients.delete(cfg.name);
+        });
+
+        client.on('error', (err) => {
+            console.error(`[MCPManager] Server "${cfg.name}" error: ${err.message}`);
+            this._clients.delete(cfg.name);
+        });
+
+        await client.connect();
+        // Pre-fetch tools and persist to config for definition.js to read at startup
+        try {
+            await client.listTools();
+            // Cache tools into the config entry so definition.js can read them from disk
+            const cfgEntry = this._configs.find(c => c.name === cfg.name);
+            if (cfgEntry && client.tools.length > 0) {
+                cfgEntry.cachedTools = client.tools.map(t => ({
+                    name:        t.name,
+                    description: t.description || ''
+                }));
+                this._saveConfig();
+            }
+        } catch (_) { /* optional */ }
+        this._clients.set(cfg.name, client);
+        console.log(`[MCPManager] ✅ Connected: "${cfg.name}" (${client.tools.length} tools)`);
+        return client;
+    }
+
+    async _stopClient(name) {
+        const client = this._clients.get(name);
+        if (client) {
+            await client.disconnect().catch(() => {});
+            this._clients.delete(name);
+        }
+    }
+
+    _appendLog(entry) {
+        this._logs.push(entry);
+        if (this._logs.length > MAX_LOG) this._logs.shift();
+    }
+
+    _readConfig() {
+        try {
+            if (!fs.existsSync(CONFIG_PATH)) return [];
+            return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+        } catch {
+            return [];
+        }
+    }
+
+    _saveConfig() {
+        try {
+            const dir = path.dirname(CONFIG_PATH);
+            if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(CONFIG_PATH, JSON.stringify(this._configs, null, 2), 'utf8');
+        } catch (e) {
+            console.error('[MCPManager] Failed to save config:', e.message);
+        }
+    }
+}
+
+MCPManager._instance = null;
+
+module.exports = MCPManager;

--- a/src/skills/core/definition.js
+++ b/src/skills/core/definition.js
@@ -1,16 +1,38 @@
 const personaManager = require('./persona');
 const packageJson = require('../../../package.json');
+const fs   = require('fs');
+const path = require('path');
 
 // ============================================================
 // 1. 核心定義
 // ============================================================
 const CORE_DEFINITION = (envInfo) => {
     const version = packageJson.version;
-    // envInfo can contain userDataDir
     const userDataDir = envInfo && typeof envInfo === 'object' ? envInfo.userDataDir : null;
     const { aiName, userName, currentRole, tone } = personaManager.get(userDataDir);
 
     let systemInfoString = typeof envInfo === 'string' ? envInfo : (envInfo.systemFingerprint || '');
+
+    // ── MCP Server 清單（從 cachedTools 讀取，MCPManager 連線後寫入） ──
+    let mcpSection = '目前尚無啟用的 MCP Server，請到 /dashboard/mcp 新增。';
+    try {
+        const cfgPath = path.resolve(process.cwd(), 'data', 'mcp-servers.json');
+        if (fs.existsSync(cfgPath)) {
+            const servers = JSON.parse(fs.readFileSync(cfgPath, 'utf8')).filter(s => s.enabled !== false);
+            if (servers.length > 0) {
+                mcpSection = '已安裝的 MCP Server：\n' + servers.map(s => {
+                    const desc = s.description || (s.command + ' ' + (s.args || []).join(' '));
+                    if (s.cachedTools && s.cachedTools.length > 0) {
+                        const toolList = s.cachedTools.map(t =>
+                            `    - \`${t.name}\`: ${t.description || ''}`
+                        ).join('\n');
+                        return `- **${s.name}** (${desc})\n${toolList}`;
+                    }
+                    return `- **${s.name}** (${desc}) — 工具清單尚未快取，請重啟後查看`;
+                }).join('\n');
+            }
+        }
+    } catch (_) { /* ignore */ }
 
     return `
 【系統識別：Golem v${version} (Ultimate Chronos + MultiAgent Edition)】
@@ -33,6 +55,18 @@ ${systemInfoString}
 1. **記憶優先**：你擁有長期記憶。若使用者提及過往偏好，請優先參考記憶，不要重複詢問。
 2. **工具探測**：不要假設電腦裡有什麼工具。不確定時，先用 \`golem-check\` 確認。
 3. **安全操作**：執行刪除 (rm/del) 或高風險操作前，必須先解釋後果。
+
+🔌 **MCP 工具 (Model Context Protocol):**
+你可以透過 \`mcp_call\` action 呼叫本地已安裝的 MCP Server 工具。
+**⚠️ 絕對禁止** 用 \`command\` 去 npx 任何 MCP server —— 它們已在本地運行，請直接用 \`mcp_call\`。
+**⚠️ 工具名稱必須完全正確** —— 請嚴格使用下方列出的工具名稱，不得自行推測或修改。
+
+格式：
+[ACTION]
+{"action":"mcp_call","server":"<server名稱>","tool":"<工具名稱>","parameters":{...}}
+[/ACTION]
+
+${mcpSection}
 `;
 };
 

--- a/web-dashboard/server.js
+++ b/web-dashboard/server.js
@@ -237,6 +237,7 @@ class WebServer {
                 '/dashboard/terminal',
                 '/dashboard/agents',
                 '/dashboard/office',
+                '/dashboard/mcp',
                 '/dashboard/system-setup'
             ];
 
@@ -1907,6 +1908,139 @@ class WebServer {
             } catch (e) {
                 console.error('Failed to delete persona:', e);
                 return res.status(500).json({ success: false, error: e.message });
+            }
+        });
+
+        // ─── MCP API Routes ──────────────────────────────────────────────────────────────────────
+        // Lazy-init MCPManager and wire its 'mcpLog' event to broadcastLog
+        const getMCPManager = async () => {
+            const MCPManager = require('../src/mcp/MCPManager');
+            const mgr = MCPManager.getInstance();
+            if (!mgr._loaded) {
+                // Wire log event once
+                if (!mgr._broadcastWired) {
+                    mgr._broadcastWired = true;
+                    mgr.on('mcpLog', (entry) => {
+                        const preview = entry.success
+                            ? (JSON.stringify(entry.result || '').slice(0, 120))
+                            : `ERROR: ${entry.error}`;
+                        this.broadcastLog({
+                            time: new Date().toLocaleTimeString('zh-TW', { hour12: false }),
+                            msg:  `[MCP] ${entry.server}/${entry.tool} (${entry.durationMs}ms) ${entry.success ? '✅' : '❌'} ${preview}`,
+                            type: 'mcp',
+                            raw:  JSON.stringify(entry),
+                            mcpEntry: entry
+                        });
+                    });
+                }
+                await mgr.load();
+            }
+            return mgr;
+        };
+
+        // GET /api/mcp/servers — list all
+        this.app.get('/api/mcp/servers', async (req, res) => {
+            try {
+                const mgr = await getMCPManager();
+                return res.json({ servers: mgr.getServers() });
+            } catch (e) {
+                console.error('[MCP] List servers error:', e);
+                return res.status(500).json({ error: e.message });
+            }
+        });
+
+        // POST /api/mcp/servers — add
+        this.app.post('/api/mcp/servers', async (req, res) => {
+            try {
+                const { name, command, args, env, enabled, description } = req.body;
+                if (!name || !command) return res.status(400).json({ error: 'Missing name or command' });
+                const mgr   = await getMCPManager();
+                const entry = await mgr.addServer({ name, command, args, env, enabled, description });
+                console.log(`[MCP] Added server: ${name}`);
+                return res.json({ success: true, server: entry });
+            } catch (e) {
+                console.error('[MCP] Add server error:', e);
+                return res.status(500).json({ error: e.message });
+            }
+        });
+
+        // PUT /api/mcp/servers/:name — update
+        this.app.put('/api/mcp/servers/:name', async (req, res) => {
+            try {
+                const { name } = req.params;
+                const mgr   = await getMCPManager();
+                const entry = await mgr.updateServer(name, req.body);
+                console.log(`[MCP] Updated server: ${name}`);
+                return res.json({ success: true, server: entry });
+            } catch (e) {
+                console.error('[MCP] Update server error:', e);
+                return res.status(500).json({ error: e.message });
+            }
+        });
+
+        // DELETE /api/mcp/servers/:name — remove
+        this.app.delete('/api/mcp/servers/:name', async (req, res) => {
+            try {
+                const { name } = req.params;
+                const mgr = await getMCPManager();
+                await mgr.removeServer(name);
+                console.log(`[MCP] Removed server: ${name}`);
+                return res.json({ success: true });
+            } catch (e) {
+                console.error('[MCP] Remove server error:', e);
+                return res.status(500).json({ error: e.message });
+            }
+        });
+
+        // POST /api/mcp/servers/:name/toggle — enable/disable
+        this.app.post('/api/mcp/servers/:name/toggle', async (req, res) => {
+            try {
+                const { name } = req.params;
+                const { enabled } = req.body;
+                const mgr   = await getMCPManager();
+                const entry = await mgr.toggleServer(name, Boolean(enabled));
+                return res.json({ success: true, server: entry });
+            } catch (e) {
+                console.error('[MCP] Toggle server error:', e);
+                return res.status(500).json({ error: e.message });
+            }
+        });
+
+        // GET /api/mcp/servers/:name/tools — list tools
+        this.app.get('/api/mcp/servers/:name/tools', async (req, res) => {
+            try {
+                const { name } = req.params;
+                const mgr   = await getMCPManager();
+                const tools = await mgr.listTools(name);
+                return res.json({ tools });
+            } catch (e) {
+                console.error('[MCP] List tools error:', e);
+                return res.status(500).json({ error: e.message });
+            }
+        });
+
+        // POST /api/mcp/servers/:name/test — test connection
+        this.app.post('/api/mcp/servers/:name/test', async (req, res) => {
+            try {
+                const { name } = req.params;
+                const mgr    = await getMCPManager();
+                const result = await mgr.testServer(name);
+                return res.json(result);
+            } catch (e) {
+                console.error('[MCP] Test server error:', e);
+                return res.status(500).json({ success: false, error: e.message });
+            }
+        });
+
+        // GET /api/mcp/logs — recent call logs
+        this.app.get('/api/mcp/logs', async (req, res) => {
+            try {
+                const limit = Math.min(Number(req.query.limit) || 100, 500);
+                const mgr   = await getMCPManager();
+                return res.json({ logs: mgr.getLogs(limit) });
+            } catch (e) {
+                console.error('[MCP] Get logs error:', e);
+                return res.status(500).json({ error: e.message });
             }
         });
 

--- a/web-dashboard/src/app/dashboard/layout.tsx
+++ b/web-dashboard/src/app/dashboard/layout.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { LayoutDashboard, Users, Database, Globe, ChevronLeft, ChevronRight, Terminal, BrainCircuit, BookOpen, Settings, User, UserPlus, MessageSquare } from "lucide-react";
+import { LayoutDashboard, Users, Database, Globe, ChevronLeft, ChevronRight, Terminal, BrainCircuit, BookOpen, Settings, User, UserPlus, MessageSquare, Plug } from "lucide-react";
 import { GolemProvider, useGolem } from "@/components/GolemContext";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { BootScreen } from "@/components/BootScreen";
@@ -22,6 +22,7 @@ function DashboardSidebar({
     const navItems = [
         { name: "直接交談", href: "/dashboard/chat", icon: MessageSquare },
         { name: "技能說明書", href: "/dashboard/skills", icon: BookOpen },
+        { name: "MCP 工具", href: "/dashboard/mcp", icon: Plug },
         { name: "人格設定", href: "/dashboard/persona", icon: User },
         { name: "Agent 會議室", href: "/dashboard/agents", icon: Users },
         { name: "辦公室模式", href: "/dashboard/office", icon: Users },

--- a/web-dashboard/src/app/dashboard/mcp/page.tsx
+++ b/web-dashboard/src/app/dashboard/mcp/page.tsx
@@ -1,0 +1,594 @@
+"use client";
+
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { socket } from "@/lib/socket";
+import { apiUrl } from "@/lib/api";
+import {
+    Plug, Plus, Trash2, RefreshCw, Zap, ChevronRight,
+    CheckCircle, XCircle, AlertCircle, Clock, ToggleLeft,
+    ToggleRight, Edit2, X, Terminal, List, Play
+} from "lucide-react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+interface MCPServer {
+    name:        string;
+    command:     string;
+    args:        string[];
+    env:         Record<string, string>;
+    enabled:     boolean;
+    description: string;
+    connected:   boolean;
+}
+
+interface MCPTool {
+    name:        string;
+    description: string;
+    inputSchema: { type: string; properties?: Record<string, unknown>; required?: string[] };
+}
+
+interface MCPLogEntry {
+    time:       string;
+    server:     string;
+    tool:       string;
+    params:     unknown;
+    success:    boolean;
+    result:     unknown;
+    error:      string | null;
+    durationMs: number;
+}
+
+// useApiBase 已移除，改用 @/lib/api 的 apiUrl()
+
+// ─── Server Card ──────────────────────────────────────────────────────────────
+function ServerCard({
+    server, selected, onSelect, onToggle, onDelete, onEdit, onTest
+}: {
+    server: MCPServer;
+    selected: boolean;
+    onSelect: () => void;
+    onToggle: (enabled: boolean) => void;
+    onDelete: () => void;
+    onEdit:   () => void;
+    onTest:   () => void;
+}) {
+    const statusColor = server.connected
+        ? 'text-emerald-400' : server.enabled
+        ? 'text-amber-400'   : 'text-zinc-500';
+
+    return (
+        <div
+            onClick={onSelect}
+            className={`group relative rounded-xl border p-4 cursor-pointer transition-all duration-200 ${
+                selected
+                    ? 'border-blue-500 bg-blue-500/10 shadow-lg shadow-blue-500/10'
+                    : 'border-border bg-card hover:border-blue-500/40 hover:bg-card/80'
+            }`}
+        >
+            {/* Status dot */}
+            <span className={`absolute top-3 right-3 w-2.5 h-2.5 rounded-full ${
+                server.connected ? 'bg-emerald-400 shadow-lg shadow-emerald-400/50 animate-pulse'
+                : server.enabled  ? 'bg-amber-400'
+                : 'bg-zinc-600'
+            }`} />
+
+            <div className="flex items-start gap-3 pr-4">
+                <div className={`mt-0.5 p-2 rounded-lg ${selected ? 'bg-blue-500/20' : 'bg-secondary'}`}>
+                    <Plug className={`w-4 h-4 ${selected ? 'text-blue-400' : 'text-muted-foreground'}`} />
+                </div>
+                <div className="flex-1 min-w-0">
+                    <p className="font-semibold text-sm text-foreground truncate">{server.name}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5 font-mono truncate">
+                        {server.command} {server.args?.join(' ')}
+                    </p>
+                    {server.description && (
+                        <p className="text-xs text-muted-foreground/70 mt-1 truncate">{server.description}</p>
+                    )}
+                    <p className={`text-xs mt-1.5 font-medium ${statusColor}`}>
+                        {server.connected ? '● Connected' : server.enabled ? '● Connecting...' : '○ Disabled'}
+                    </p>
+                </div>
+            </div>
+
+            {/* Action bar */}
+            <div className="flex items-center gap-1 mt-3 pt-3 border-t border-border/50 opacity-0 group-hover:opacity-100 transition-opacity">
+                <button
+                    onClick={(e) => { e.stopPropagation(); onToggle(!server.enabled); }}
+                    className="flex-1 flex items-center justify-center gap-1.5 px-2 py-1 rounded-lg text-xs hover:bg-secondary transition-colors"
+                    title={server.enabled ? '停用' : '啟用'}
+                >
+                    {server.enabled
+                        ? <><ToggleRight className="w-3.5 h-3.5 text-blue-400" /><span className="text-blue-400">啟用中</span></>
+                        : <><ToggleLeft  className="w-3.5 h-3.5 text-zinc-500" /><span className="text-zinc-500">已停用</span></>
+                    }
+                </button>
+                <button onClick={(e) => { e.stopPropagation(); onTest(); }}
+                    className="p-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-amber-400 transition-colors" title="測試連線">
+                    <Zap className="w-3.5 h-3.5" />
+                </button>
+                <button onClick={(e) => { e.stopPropagation(); onEdit(); }}
+                    className="p-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-blue-400 transition-colors" title="編輯">
+                    <Edit2 className="w-3.5 h-3.5" />
+                </button>
+                <button onClick={(e) => { e.stopPropagation(); onDelete(); }}
+                    className="p-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-red-400 transition-colors" title="刪除">
+                    <Trash2 className="w-3.5 h-3.5" />
+                </button>
+            </div>
+        </div>
+    );
+}
+
+// ─── Tool Inspector ───────────────────────────────────────────────────────────
+function ToolInspector({ server }: { server: MCPServer | null }) {
+    const [tools,   setTools]   = useState<MCPTool[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error,   setError]   = useState<string | null>(null);
+    const [selected, setSelected] = useState<MCPTool | null>(null);
+
+    useEffect(() => {
+        if (!server || !server.connected) { setTools([]); return; }
+        setLoading(true); setError(null);
+        fetch(apiUrl(`/api/mcp/servers/${encodeURIComponent(server.name)}/tools`))
+            .then(r => r.json())
+            .then(d => { setTools(d.tools || []); setLoading(false); })
+            .catch(e => { setError(e.message); setLoading(false); });
+    }, [server]);
+
+    if (!server) {
+        return (
+            <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground gap-3">
+                <List className="w-10 h-10 opacity-30" />
+                <p className="text-sm">選擇左側的 MCP Server 以查看可用工具</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex-1 flex flex-col overflow-hidden">
+            <div className="px-5 py-3 border-b border-border flex items-center justify-between">
+                <div>
+                    <h3 className="font-semibold text-foreground">{server.name}</h3>
+                    <p className="text-xs text-muted-foreground font-mono">{server.command} {server.args?.join(' ')}</p>
+                </div>
+                {loading && <RefreshCw className="w-4 h-4 animate-spin text-muted-foreground" />}
+            </div>
+
+            {error && (
+                <div className="m-4 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm flex items-center gap-2">
+                    <XCircle className="w-4 h-4 flex-shrink-0" /> {error}
+                </div>
+            )}
+
+            {!server.connected && !loading && (
+                <div className="m-4 p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-400 text-sm flex items-center gap-2">
+                    <AlertCircle className="w-4 h-4 flex-shrink-0" /> Server 未連線，請先啟用
+                </div>
+            )}
+
+            <div className="flex-1 overflow-auto p-4 flex gap-4">
+                {/* Tool list */}
+                <div className="w-56 flex-shrink-0 space-y-1">
+                    <p className="text-xs font-semibold text-muted-foreground px-2 mb-2 uppercase tracking-wider">
+                        工具 ({tools.length})
+                    </p>
+                    {tools.map(t => (
+                        <button
+                            key={t.name}
+                            onClick={() => setSelected(t)}
+                            className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors flex items-center gap-2 ${
+                                selected?.name === t.name
+                                    ? 'bg-blue-500/20 text-blue-300 border border-blue-500/30'
+                                    : 'hover:bg-secondary text-foreground'
+                            }`}
+                        >
+                            <Play className="w-3 h-3 flex-shrink-0" />
+                            <span className="truncate font-mono text-xs">{t.name}</span>
+                        </button>
+                    ))}
+                    {tools.length === 0 && !loading && server.connected && (
+                        <p className="text-xs text-muted-foreground px-2">無可用工具</p>
+                    )}
+                </div>
+
+                {/* Tool detail */}
+                <div className="flex-1 min-w-0">
+                    {selected ? (
+                        <div className="bg-secondary/50 rounded-xl border border-border p-4 space-y-4">
+                            <div>
+                                <p className="font-mono font-semibold text-blue-300 text-sm">{selected.name}</p>
+                                <p className="text-sm text-muted-foreground mt-1">{selected.description}</p>
+                            </div>
+                            {selected.inputSchema?.properties && (
+                                <div>
+                                    <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">參數</p>
+                                    <div className="space-y-2">
+                                        {Object.entries(selected.inputSchema.properties).map(([key, schema]: [string, any]) => (
+                                            <div key={key} className="flex items-start gap-3 bg-background/50 rounded-lg p-2">
+                                                <span className="font-mono text-xs text-blue-300 flex-shrink-0">{key}</span>
+                                                <div>
+                                                    {selected.inputSchema.required?.includes(key) && (
+                                                        <span className="text-xs text-red-400 mr-2">必填</span>
+                                                    )}
+                                                    <span className="text-xs text-muted-foreground">{schema?.description || schema?.type}</span>
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+                            <div className="text-xs text-muted-foreground/60 pt-2 border-t border-border">
+                                <p>Action 格式 (用於 Golem 對話):</p>
+                                <pre className="mt-1 bg-background p-2 rounded-lg text-[11px] text-emerald-300 overflow-x-auto whitespace-pre-wrap">{
+                                    JSON.stringify({
+                                        action: "mcp_call",
+                                        server: server.name,
+                                        tool:   selected.name,
+                                        parameters: {}
+                                    }, null, 2)
+                                }</pre>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="flex items-center justify-center h-full text-muted-foreground/50 text-sm">
+                            點選左側工具查看詳情
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+// ─── Log Panel ────────────────────────────────────────────────────────────────
+function LogPanel({ logs }: { logs: MCPLogEntry[] }) {
+    const bottomRef = useRef<HTMLDivElement>(null);
+    useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [logs]);
+
+    return (
+        <div className="border-t border-border bg-black/40 h-52 overflow-y-auto font-mono text-xs p-3 space-y-1">
+            {logs.length === 0 && (
+                <p className="text-muted-foreground/50 text-center pt-4">尚無 MCP 呼叫記錄</p>
+            )}
+            {logs.map((l, i) => (
+                <div key={i} className={`flex items-start gap-2 ${l.success ? 'text-emerald-300' : 'text-red-400'}`}>
+                    <span className="text-muted-foreground/50 whitespace-nowrap">
+                        {new Date(l.time).toLocaleTimeString('zh-TW', { hour12: false })}
+                    </span>
+                    {l.success ? <CheckCircle className="w-3 h-3 mt-0.5 flex-shrink-0" /> : <XCircle className="w-3 h-3 mt-0.5 flex-shrink-0" />}
+                    <span className="text-blue-300">[{l.server}/{l.tool}]</span>
+                    <span className="text-muted-foreground">({l.durationMs}ms)</span>
+                    {l.error && <span className="text-red-400">{l.error}</span>}
+                </div>
+            ))}
+            <div ref={bottomRef} />
+        </div>
+    );
+}
+
+// ─── Add/Edit Dialog ──────────────────────────────────────────────────────────
+function ServerDialog({
+    initial, onSave, onClose
+}: {
+    initial: Partial<MCPServer> | null;
+    onSave:  (data: Partial<MCPServer>) => void;
+    onClose: () => void;
+}) {
+    const [form, setForm] = useState({
+        name:        initial?.name        || '',
+        command:     initial?.command     || '',
+        argsStr:     (initial?.args || []).join(' '),
+        envStr:      Object.entries(initial?.env || {}).map(([k, v]) => `${k}=${v}`).join('\n'),
+        description: initial?.description || '',
+        enabled:     initial?.enabled !== false
+    });
+
+    const handleSave = () => {
+        const args = form.argsStr.trim() ? form.argsStr.trim().split(/\s+/) : [];
+        const env: Record<string, string> = {};
+        for (const line of form.envStr.split('\n')) {
+            const eq = line.indexOf('=');
+            if (eq > 0) env[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+        }
+        onSave({ name: form.name, command: form.command, args, env, description: form.description, enabled: form.enabled });
+    };
+
+    const isEdit = !!initial?.name;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+            <div className="bg-card border border-border rounded-2xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden">
+                <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+                    <h2 className="font-bold text-lg">{isEdit ? '編輯 MCP Server' : '新增 MCP Server'}</h2>
+                    <button onClick={onClose} className="text-muted-foreground hover:text-foreground"><X className="w-5 h-5" /></button>
+                </div>
+                <div className="px-6 py-5 space-y-4">
+                    {[
+                        { label: '名稱 *', key: 'name', placeholder: 'codex', mono: false, disabled: isEdit },
+                        { label: '執行指令 *', key: 'command', placeholder: 'npx', mono: true },
+                        { label: '參數 (空格分隔)', key: 'argsStr', placeholder: '-y @modelcontextprotocol/server-codex', mono: true },
+                    ].map(({ label, key, placeholder, mono, disabled }) => (
+                        <div key={key}>
+                            <label className="text-sm text-muted-foreground mb-1 block">{label}</label>
+                            <input
+                                className={`w-full bg-secondary border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-blue-500 ${mono ? 'font-mono' : ''} ${disabled ? 'opacity-50' : ''}`}
+                                value={(form as any)[key]}
+                                placeholder={placeholder}
+                                disabled={disabled}
+                                onChange={e => setForm(f => ({ ...f, [key]: e.target.value }))}
+                            />
+                        </div>
+                    ))}
+                    <div>
+                        <label className="text-sm text-muted-foreground mb-1 block">環境變數 (KEY=VALUE，每行一個)</label>
+                        <textarea
+                            className="w-full bg-secondary border border-border rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:border-blue-500 resize-none h-20"
+                            value={form.envStr}
+                            placeholder={"ANTHROPIC_API_KEY=sk-...\nNODE_ENV=production"}
+                            onChange={e => setForm(f => ({ ...f, envStr: e.target.value }))}
+                        />
+                    </div>
+                    <div>
+                        <label className="text-sm text-muted-foreground mb-1 block">描述</label>
+                        <input
+                            className="w-full bg-secondary border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+                            value={form.description}
+                            placeholder="Codex CLI MCP Server"
+                            onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+                        />
+                    </div>
+                    <label className="flex items-center gap-3 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            className="rounded border-border accent-blue-500"
+                            checked={form.enabled}
+                            onChange={e => setForm(f => ({ ...f, enabled: e.target.checked }))}
+                        />
+                        <span className="text-sm">啟用 (立即建立連線)</span>
+                    </label>
+                </div>
+                <div className="flex justify-end gap-3 px-6 py-4 border-t border-border bg-secondary/30">
+                    <button onClick={onClose} className="px-4 py-2 rounded-lg text-sm hover:bg-secondary transition-colors">取消</button>
+                    <button
+                        onClick={handleSave}
+                        disabled={!form.name || !form.command}
+                        className="px-4 py-2 rounded-lg text-sm bg-blue-600 hover:bg-blue-500 text-white font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        {isEdit ? '儲存' : '新增'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+export default function MCPPage() {
+    const [servers,     setServers]     = useState<MCPServer[]>([]);
+    const [selected,    setSelected]    = useState<MCPServer | null>(null);
+    const [logs,        setLogs]        = useState<MCPLogEntry[]>([]);
+    const [loading,     setLoading]     = useState(true);
+    const [dialog,      setDialog]      = useState<{ mode: 'add' | 'edit'; initial: Partial<MCPServer> | null } | null>(null);
+    const [toast,       setToast]       = useState<{ msg: string; ok: boolean } | null>(null);
+    const [testResult,  setTestResult]  = useState<{ server: string; ok: boolean; msg: string } | null>(null);
+
+    const showToast = (msg: string, ok = true) => {
+        setToast({ msg, ok });
+        setTimeout(() => setToast(null), 3000);
+    };
+
+    // ── Fetch servers ─────────────────────────────────────────────
+    const fetchServers = useCallback(async () => {
+        setLoading(true);
+        try {
+            const r = await fetch(apiUrl('/api/mcp/servers'));
+            const d = await r.json();
+            setServers(d.servers || []);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    // ── Fetch initial logs ────────────────────────────────────────
+    const fetchLogs = useCallback(async () => {
+        try {
+            const r = await fetch(apiUrl('/api/mcp/logs?limit=100'));
+            const d = await r.json();
+            setLogs(d.logs || []);
+        } catch { /* ignore */ }
+    }, []);
+
+    useEffect(() => { fetchServers(); fetchLogs(); }, [fetchServers, fetchLogs]);
+
+    // ── Socket — real-time MCP logs ───────────────────────────────
+    useEffect(() => {
+        const handler = (data: any) => {
+            if (data.type === 'mcp' && data.mcpEntry) {
+                setLogs(prev => [...prev.slice(-199), data.mcpEntry]);
+            }
+        };
+        socket.on('log', handler);
+        return () => { socket.off('log', handler); };
+    }, []);
+
+    // ── Keep selected in sync after refresh ───────────────────────
+    useEffect(() => {
+        if (selected) {
+            const fresh = servers.find(s => s.name === selected.name);
+            if (fresh) setSelected(fresh);
+        }
+    }, [servers]);
+
+    // ── Actions ───────────────────────────────────────────────────
+    const handleToggle = async (name: string, enabled: boolean) => {
+        await fetch(apiUrl(`/api/mcp/servers/${encodeURIComponent(name)}/toggle`), {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ enabled })
+        });
+        showToast(enabled ? `${name} 已啟用` : `${name} 已停用`);
+        await fetchServers();
+    };
+
+    const handleDelete = async (name: string) => {
+        if (!confirm(`確定要刪除 "${name}"？`)) return;
+        await fetch(apiUrl(`/api/mcp/servers/${encodeURIComponent(name)}`), { method: 'DELETE' });
+        showToast(`${name} 已刪除`);
+        if (selected?.name === name) setSelected(null);
+        await fetchServers();
+    };
+
+    const handleTest = async (name: string) => {
+        setTestResult(null);
+        try {
+            const r = await fetch(apiUrl(`/api/mcp/servers/${encodeURIComponent(name)}/test`), { method: 'POST' });
+            const d = await r.json();
+            setTestResult({ server: name, ok: d.success, msg: d.success ? `發現 ${d.toolCount} 個工具` : d.error });
+            setTimeout(() => setTestResult(null), 4000);
+        } catch (e: any) {
+            setTestResult({ server: name, ok: false, msg: e.message });
+            setTimeout(() => setTestResult(null), 4000);
+        }
+    };
+
+    const handleSave = async (data: Partial<MCPServer>) => {
+        const isEdit = !!dialog?.initial?.name;
+        const url = isEdit
+            ? apiUrl(`/api/mcp/servers/${encodeURIComponent(dialog!.initial!.name!)}`)
+            : apiUrl('/api/mcp/servers');
+        const method = isEdit ? 'PUT' : 'POST';
+
+        try {
+            const r = await fetch(url, {
+                method, headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            const d = await r.json();
+            if (d.error) throw new Error(d.error);
+            showToast(isEdit ? '更新成功' : '新增成功');
+            setDialog(null);
+            await fetchServers();
+        } catch (e: any) {
+            showToast(e.message, false);
+        }
+    };
+
+    // ─────────────────────────────────────────────────────────────
+    return (
+        <div className="flex flex-col h-full overflow-hidden">
+            {/* Header */}
+            <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-card/50 backdrop-blur-sm flex-shrink-0">
+                <div className="flex items-center gap-3">
+                    <div className="p-2 rounded-xl bg-blue-500/15 border border-blue-500/30">
+                        <Plug className="w-5 h-5 text-blue-400" />
+                    </div>
+                    <div>
+                        <h1 className="text-lg font-bold">MCP 工具管理</h1>
+                        <p className="text-xs text-muted-foreground">Model Context Protocol — 本地工具整合中心</p>
+                    </div>
+                </div>
+                <div className="flex items-center gap-2">
+                    <button
+                        onClick={fetchServers}
+                        className="p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+                        title="重新整理"
+                    >
+                        <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                    </button>
+                    <button
+                        onClick={() => setDialog({ mode: 'add', initial: null })}
+                        className="flex items-center gap-2 px-4 py-2 rounded-xl bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold transition-colors shadow-lg shadow-blue-500/20"
+                    >
+                        <Plus className="w-4 h-4" />
+                        新增 Server
+                    </button>
+                </div>
+            </div>
+
+            {/* Test result toast */}
+            {testResult && (
+                <div className={`mx-6 mt-3 p-3 rounded-xl border text-sm flex items-center gap-2 flex-shrink-0 ${
+                    testResult.ok
+                        ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
+                        : 'bg-red-500/10 border-red-500/30 text-red-400'
+                }`}>
+                    {testResult.ok ? <CheckCircle className="w-4 h-4" /> : <XCircle className="w-4 h-4" />}
+                    <span><strong>{testResult.server}</strong> — {testResult.msg}</span>
+                </div>
+            )}
+
+            {/* Body */}
+            <div className="flex-1 flex overflow-hidden">
+                {/* ── Left panel: server list ── */}
+                <div className="w-72 flex-shrink-0 border-r border-border flex flex-col overflow-hidden">
+                    <div className="px-4 py-3 border-b border-border bg-secondary/20">
+                        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                            Servers ({servers.filter(s => s.connected).length}/{servers.length} 已連線)
+                        </p>
+                    </div>
+                    <div className="flex-1 overflow-y-auto p-3 space-y-2">
+                        {loading && servers.length === 0 && (
+                            <div className="flex items-center justify-center h-32 text-muted-foreground">
+                                <RefreshCw className="w-5 h-5 animate-spin" />
+                            </div>
+                        )}
+                        {!loading && servers.length === 0 && (
+                            <div className="flex flex-col items-center justify-center h-48 text-muted-foreground gap-3">
+                                <Plug className="w-8 h-8 opacity-30" />
+                                <p className="text-sm text-center">尚未設定任何 MCP Server<br />點擊「新增 Server」開始</p>
+                            </div>
+                        )}
+                        {servers.map(s => (
+                            <ServerCard
+                                key={s.name}
+                                server={s}
+                                selected={selected?.name === s.name}
+                                onSelect={() => setSelected(s)}
+                                onToggle={(enabled) => handleToggle(s.name, enabled)}
+                                onDelete={() => handleDelete(s.name)}
+                                onEdit={() => setDialog({ mode: 'edit', initial: s })}
+                                onTest={() => handleTest(s.name)}
+                            />
+                        ))}
+                    </div>
+                </div>
+
+                {/* ── Right panel: tool inspector + logs ── */}
+                <div className="flex-1 flex flex-col overflow-hidden">
+                    <div className="flex-1 overflow-hidden flex">
+                        <ToolInspector server={selected} />
+                    </div>
+
+                    {/* Log panel */}
+                    <div className="flex-shrink-0">
+                        <div className="flex items-center gap-2 px-4 py-2 border-t border-border bg-secondary/20">
+                            <Terminal className="w-3.5 h-3.5 text-muted-foreground" />
+                            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">MCP 呼叫 Log</span>
+                            <span className="ml-auto text-xs text-muted-foreground">{logs.length} 筆記錄</span>
+                        </div>
+                        <LogPanel logs={logs} />
+                    </div>
+                </div>
+            </div>
+
+            {/* Add/Edit dialog */}
+            {dialog && (
+                <ServerDialog
+                    initial={dialog.initial}
+                    onSave={handleSave}
+                    onClose={() => setDialog(null)}
+                />
+            )}
+
+            {/* Toast */}
+            {toast && (
+                <div className={`fixed bottom-6 right-6 z-50 px-4 py-3 rounded-xl shadow-2xl text-sm font-medium flex items-center gap-2 transition-all ${
+                    toast.ok
+                        ? 'bg-emerald-600 text-white'
+                        : 'bg-red-600 text-white'
+                }`}>
+                    {toast.ok ? <CheckCircle className="w-4 h-4" /> : <XCircle className="w-4 h-4" />}
+                    {toast.msg}
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
本 PR 為 Project Golem 引入了 **Model Context Protocol (MCP)** 支援，使 Golem 能夠作為 MCP Client 無縫調用本地的 MCP Server 工具（如 `hacker-news`, `chrome-devtools` 等）。同時，在 Web Dashboard 中新增了專屬的 MCP 管理頁面，支援實時日誌監控與工具配置。
## 主要變更 (Key Changes)
### 核心與後端 (Core & Backend)
- **[NEW] [src/mcp/MCPClient.js](cci:7://file:///Users/alan_wang/project-golem/src/mcp/MCPClient.js:0:0-0:0)**: 實作基於 JSON-RPC 2.0 over stdio 的 MCP 客戶端。
- **[NEW] [src/mcp/MCPManager.js](cci:7://file:///Users/alan_wang/project-golem/src/mcp/MCPManager.js:0:0-0:0)**: 
    - 管理 MCP Server 生命週期與連線狀態。
    - 持久化配置於 [data/mcp-servers.json](cci:7://file:///Users/alan_wang/project-golem/data/mcp-servers.json:0:0-0:0)。
    - **快取機制**：自動將 Server 工具清單寫回磁碟，提升啟動時的 Prompt 注入效率。
- **[MODIFY] [src/core/action_handlers/SkillHandler.js](cci:7://file:///Users/alan_wang/project-golem/src/core/action_handlers/SkillHandler.js:0:0-0:0)**: 支援 `mcp_call` 行動任務，並具備自動連線 (Lazy Load) 能力。
- **[MODIFY] [src/skills/core/definition.js](cci:7://file:///Users/alan_wang/project-golem/src/skills/core/definition.js:0:0-0:0)**: 
    - 動態注入已啟用的 MCP Server 清單與精確的工具名稱說明。
    - 明確引導 AI 使用 `mcp_call` 而非傳統指令模式。
### Web Dashboard
- **[NEW] `/dashboard/mcp`**: 
    - **Server 管理**：支援 CRUD、停用/啟用與連線測試。
    - **工具檢視**：實時查詢 Server 提供的工具 Schema。
    - **實時日誌**：串接 Socket.io，視覺化呈現 MCP 調用參數與結果。
- **[MODIFY] [server.js](cci:7://file:///Users/alan_wang/project-golem/web-dashboard/server.js:0:0-0:0)**: 新增 8 個 REST API 端口處理 MCP 相關事務。
### 穩定性與 Bug Fix
- **API URL 修正**：統一使用 `@/lib/api` 解決 localhost 與遠端訪問的 URL 解析衝突。
- **連線初始化**：修正 [SkillHandler](cci:2://file:///Users/alan_wang/project-golem/src/core/action_handlers/SkillHandler.js:3:0-69:1) 調用時未先行載入 [MCPManager](cci:2://file:///Users/alan_wang/project-golem/src/mcp/MCPManager.js:16:0-261:1) 導致的連線錯誤。
- **日誌溢位修復**：解決 [server.js](cci:7://file:///Users/alan_wang/project-golem/web-dashboard/server.js:0:0-0:0) 中 `MAX_LOG` 之 ReferenceError。
## 驗證結果 (Verification)
- ✅ 成功安裝並聯動 `hacker-news` MCP Server（抓取頭條功能正常）。
- ✅ 成功安裝 `chrome-devtools-mcp` 並完成 29 個 Web 調試工具的 Schema 解析。
- ✅ Dashboard 頁面可實時觀察到 `mcp_call` 的 JSON-RPC 往返細節。
- ✅ 多次 Golem 對話測試確認 AI 已能根據 Prompt 列出的工具名稱準確發起調用。
## 相關事項 (Notes)
> [!IMPORTANT]
> 本次更新後，請確保 [data/mcp-servers.json](cci:7://file:///Users/alan_wang/project-golem/data/mcp-servers.json:0:0-0:0) 配置正確。手動新增 MCP Server 時，建議使用絕對路徑以避免 Node.js `~` 展開失敗。