### PR TITLE
fix: correct dashboard routing and playwright doctor check

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -69,15 +69,14 @@ const testPort = (port) => {
 
 // 5b. Check Playwright Chromium binary
 try {
-    const { execSync } = require('child_process');
-    // npx playwright install chromium --dry-run exits 0 only if already installed
-    const result = execSync('npx playwright install chromium --dry-run 2>&1', { stdio: 'pipe' }).toString();
-    // If the output says it would download, the browser is NOT installed
-    const needsDownload = result.includes('Download url');
+    const { chromium } = require('playwright');
+    const executablePath = chromium.executablePath();
+    const isInstalled = Boolean(executablePath) && fs.existsSync(executablePath);
+
     check(
         'Playwright Chromium',
-        !needsDownload,
-        'Installed',
+        isInstalled,
+        `Installed (${executablePath})`,
         'Not installed - Playwright browser binary is missing.',
         'Run `npx playwright install chromium` (and on Linux: `sudo npx playwright install-deps chromium`)',
         false

--- a/web-dashboard/server/registerStaticRoutes.js
+++ b/web-dashboard/server/registerStaticRoutes.js
@@ -138,7 +138,13 @@ module.exports = function registerStaticRoutes(server) {
 
     server.app.get(/\/dashboard.*/, (req, res, next) => {
         const normalizedPath = req.path.replace(/\/$/, '');
-        if (normalizedPath === '/dashboard/system-setup' || normalizedPath === '/dashboard/login' || req.path.startsWith('/api/')) {
+        if (
+            normalizedPath === '/dashboard/system-setup' ||
+            normalizedPath === '/dashboard/system-setup.html' ||
+            normalizedPath === '/dashboard/login' ||
+            normalizedPath === '/dashboard/login.html' ||
+            req.path.startsWith('/api/')
+        ) {
             return next();
         }
 
@@ -151,8 +157,8 @@ module.exports = function registerStaticRoutes(server) {
         try {
             const isConfigured = process.env.SYSTEM_CONFIGURED === 'true';
             if (!isConfigured) {
-                console.log(`🚩 [WebServer] System NOT initialized. Redirecting ${req.path} to /dashboard/system-setup`);
-                return res.redirect('/dashboard/system-setup');
+                console.log(`🚩 [WebServer] System NOT initialized. Redirecting ${req.path} to /dashboard/system-setup.html`);
+                return res.redirect('/dashboard/system-setup.html');
             }
         } catch (e) {
             console.error('Failed to check config during redirect:', e.message);
@@ -162,17 +168,17 @@ module.exports = function registerStaticRoutes(server) {
 
     dashboardRoutes.forEach((route) => {
         server.app.get(route, (req, res) => {
-            const fileName = route === '/dashboard' ? 'dashboard.html' : `${route.replace(/^\//, '')}.html`;
-            const fullPath = path.join(publicPath, fileName);
-            return sendDashboardFile(res, fullPath);
+            const htmlPath = route === '/dashboard' ? '/dashboard.html' : `${route}.html`;
+            return res.redirect(htmlPath);
         });
     });
 
     server.app.get(/\/dashboard\/.*/, (req, res) => {
         const normalizedPath = req.path.replace(/\/$/, '');
-        const htmlFileName = `${normalizedPath.replace(/^\//, '')}.html`;
-        const fullPath = path.join(publicPath, htmlFileName);
+        const htmlPath = normalizedPath.endsWith('.html')
+            ? normalizedPath
+            : `${normalizedPath}.html`;
 
-        return sendDashboardFile(res, fullPath);
+        return res.redirect(htmlPath);
     });
 };


### PR DESCRIPTION
## Summary
- fix false negative Playwright Chromium detection in doctor script
- fix dashboard static route handling and redirects for exported HTML pages
- verify dashboard loads successfully after startup

## Verification
- npm run doctor
- curl -L http://127.0.0.1:3000/dashboard returned 200
- browser check confirmed Project Golem Dashboard loads
