### PR TITLE
fix: stabilize dashboard routing and missing MCP runtime handling

### DIFF
--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -69,15 +69,14 @@ const testPort = (port) => {
 
 // 5b. Check Playwright Chromium binary
 try {
-    const { execSync } = require('child_process');
-    // npx playwright install chromium --dry-run exits 0 only if already installed
-    const result = execSync('npx playwright install chromium --dry-run 2>&1', { stdio: 'pipe' }).toString();
-    // If the output says it would download, the browser is NOT installed
-    const needsDownload = result.includes('Download url');
+    const { chromium } = require('playwright');
+    const executablePath = chromium.executablePath();
+    const isInstalled = Boolean(executablePath) && fs.existsSync(executablePath);
+
     check(
         'Playwright Chromium',
-        !needsDownload,
-        'Installed',
+        isInstalled,
+        `Installed (${executablePath})`,
         'Not installed - Playwright browser binary is missing.',
         'Run `npx playwright install chromium` (and on Linux: `sudo npx playwright install-deps chromium`)',
         false

--- a/src/mcp/MCPClient.js
+++ b/src/mcp/MCPClient.js
@@ -5,6 +5,8 @@
  * 實作 initialize handshake、tools/list、tools/call。
  */
 
+const fs = require('fs');
+const path = require('path');
 const { spawn } = require('child_process');
 const { EventEmitter } = require('events');
 
@@ -37,6 +39,13 @@ class MCPClient extends EventEmitter {
     // ─── Public API ────────────────────────────────────────────────
     async connect() {
         if (this._connected) return;
+
+        const resolvedCommand = this._resolveCommandPath();
+        if (resolvedCommand && !fs.existsSync(resolvedCommand)) {
+            const err = new Error(`MCP server executable not found: ${resolvedCommand}`);
+            console.error(`[MCPClient:${this.name}] ${err.message}`);
+            throw err;
+        }
 
         return new Promise((resolve, reject) => {
             const env = { ...process.env, ...this.env };
@@ -150,6 +159,15 @@ class MCPClient extends EventEmitter {
         if (!this._process || !this._process.stdin.writable) return;
         const msg = JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n';
         this._process.stdin.write(msg);
+    }
+
+    _resolveCommandPath() {
+        if (!this.command) return null;
+        if (path.isAbsolute(this.command)) return this.command;
+        if (this.command.startsWith('./') || this.command.startsWith('../')) {
+            return path.resolve(process.cwd(), this.command);
+        }
+        return null;
     }
 
     _onData(chunk) {

--- a/src/mcp/MCPManager.js
+++ b/src/mcp/MCPManager.js
@@ -182,6 +182,11 @@ class MCPManager extends EventEmitter {
         const cfg = this._configs.find(c => c.name === name);
         if (!cfg) throw new Error(`MCP server "${name}" not found`);
 
+        const resolvedCommand = this._resolveCommandPath(cfg.command);
+        if (resolvedCommand && !fs.existsSync(resolvedCommand)) {
+            throw new Error(`MCP server executable not found: ${resolvedCommand}`);
+        }
+
         const testClient = new MCPClient({ ...cfg, timeout: 10000 });
         try {
             await testClient.connect();
@@ -239,6 +244,15 @@ class MCPManager extends EventEmitter {
     _appendLog(entry) {
         this._logs.push(entry);
         if (this._logs.length > MAX_LOG) this._logs.shift();
+    }
+
+    _resolveCommandPath(command) {
+        if (!command) return null;
+        if (path.isAbsolute(command)) return command;
+        if (command.startsWith('./') || command.startsWith('../')) {
+            return path.resolve(process.cwd(), command);
+        }
+        return null;
     }
 
     _readConfig() {

--- a/web-dashboard/server/registerStaticRoutes.js
+++ b/web-dashboard/server/registerStaticRoutes.js
@@ -138,7 +138,13 @@ module.exports = function registerStaticRoutes(server) {
 
     server.app.get(/\/dashboard.*/, (req, res, next) => {
         const normalizedPath = req.path.replace(/\/$/, '');
-        if (normalizedPath === '/dashboard/system-setup' || normalizedPath === '/dashboard/login' || req.path.startsWith('/api/')) {
+        if (
+            normalizedPath === '/dashboard/system-setup' ||
+            normalizedPath === '/dashboard/system-setup.html' ||
+            normalizedPath === '/dashboard/login' ||
+            normalizedPath === '/dashboard/login.html' ||
+            req.path.startsWith('/api/')
+        ) {
             return next();
         }
 
@@ -151,8 +157,8 @@ module.exports = function registerStaticRoutes(server) {
         try {
             const isConfigured = process.env.SYSTEM_CONFIGURED === 'true';
             if (!isConfigured) {
-                console.log(`🚩 [WebServer] System NOT initialized. Redirecting ${req.path} to /dashboard/system-setup`);
-                return res.redirect('/dashboard/system-setup');
+                console.log(`🚩 [WebServer] System NOT initialized. Redirecting ${req.path} to /dashboard/system-setup.html`);
+                return res.redirect('/dashboard/system-setup.html');
             }
         } catch (e) {
             console.error('Failed to check config during redirect:', e.message);
@@ -162,17 +168,17 @@ module.exports = function registerStaticRoutes(server) {
 
     dashboardRoutes.forEach((route) => {
         server.app.get(route, (req, res) => {
-            const fileName = route === '/dashboard' ? 'dashboard.html' : `${route.replace(/^\//, '')}.html`;
-            const fullPath = path.join(publicPath, fileName);
-            return sendDashboardFile(res, fullPath);
+            const htmlPath = route === '/dashboard' ? '/dashboard.html' : `${route}.html`;
+            return res.redirect(htmlPath);
         });
     });
 
     server.app.get(/\/dashboard\/.*/, (req, res) => {
         const normalizedPath = req.path.replace(/\/$/, '');
-        const htmlFileName = `${normalizedPath.replace(/^\//, '')}.html`;
-        const fullPath = path.join(publicPath, htmlFileName);
+        const htmlPath = normalizedPath.endsWith('.html')
+            ? normalizedPath
+            : `${normalizedPath}.html`;
 
-        return sendDashboardFile(res, fullPath);
+        return res.redirect(htmlPath);
     });
 };


### PR DESCRIPTION
## Summary
- fix false negative Playwright Chromium detection in doctor script
- fix dashboard static route handling and redirects for exported HTML pages
- fail fast with a clear error when a configured MCP executable is missing
- avoid long notebooklm MCP test timeouts when notebooklm_venv is absent

## Verification
- npm run doctor
- curl -L http://127.0.0.1:3000/dashboard returned 200
- POST /api/mcp/servers/notebooklm/test now returns a clear missing-executable error
- browser check confirmed Project Golem Dashboard loads
