### PR TITLE
fix: make chrome-devtools MCP launcher portable

### DIFF
--- a/data/mcp-servers.json
+++ b/data/mcp-servers.json
@@ -1,16 +1,17 @@
 [
   {
     "name": "chrome-devtools",
-    "command": "node",
+    "command": "npx",
     "args": [
-      "/Users/arvin/.npm/_npx/15c61037b1978c83/node_modules/chrome-devtools-mcp/build/src/bin/chrome-devtools-mcp.js",
+      "-y",
+      "chrome-devtools-mcp@latest",
       "--headless",
       "--no-usage-statistics",
       "--no-performance-crux",
       "--chromeArg=--accept-lang=zh-TW,zh;q=0.9",
       "--chromeArg=--no-sandbox",
       "--chromeArg=--disable-setuid-sandbox",
-      "--userDataDir=/Users/arvin/Desktop/project-golem-plus/.golem/chrome-devtools-profile"
+      "--userDataDir=.golem/chrome-devtools-profile"
     ],
     "env": {},
     "timeout": 120000,


### PR DESCRIPTION
fix: make chrome-devtools MCP launcher portable