### PR TITLE
Release v9.6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p><strong>可長期陪跑的自主 AI 代理系統：Web Gemini、Ollama、LM Studio、多代理、技能、記憶與 Web Dashboard。</strong></p>
 
   <p>
-    <img src="https://img.shields.io/badge/Version-9.6.7-blue?style=for-the-badge" alt="Version">
+    <img src="https://img.shields.io/badge/Version-9.6.8-blue?style=for-the-badge" alt="Version">
     <img src="https://img.shields.io/badge/Node.js-20--22-green?style=for-the-badge&logo=nodedotjs" alt="Node.js">
     <img src="https://img.shields.io/badge/Backend-Gemini%20Web%20%7C%20Ollama%20%7C%20LM%20Studio-orange?style=for-the-badge" alt="Backends">
     <img src="https://img.shields.io/badge/Dashboard-Next.js%2016-black?style=for-the-badge&logo=nextdotjs" alt="Dashboard">

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -4,7 +4,7 @@
   <p><b>Ultimate Chronos + MultiAgent + Social Node Edition</b></p>
 
   <p>
-    <img src="https://img.shields.io/badge/Version-9.6.7-blue?style=for-the-badge" alt="Version">
+    <img src="https://img.shields.io/badge/Version-9.6.8-blue?style=for-the-badge" alt="Version">
     <img src="https://img.shields.io/badge/Engine-Node.js%2020-green?style=for-the-badge&logo=nodedotjs" alt="Engine">
     <img src="https://img.shields.io/badge/Brain-Gemini%20Web%20%7C%20Ollama-orange?style=for-the-badge&logo=google" alt="Brain">
     <img src="https://img.shields.io/badge/Platform-Telegram%20%7C%20Discord-blue?style=for-the-badge" alt="Platform">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-golem",
-  "version": "9.6.7",
+  "version": "9.6.8",
   "description": "Project Golem v9.5 (Ultimate Chronos + MultiAgent Edition) - Collaborative AI System",
   "main": "index.js",
   "scripts": {

--- a/packages/protocol/NeuroShunter.js
+++ b/packages/protocol/NeuroShunter.js
@@ -358,16 +358,17 @@ class NeuroShunter {
 
                 observationLines.push('請根據以上資訊修正你的 [GOLEM_ACTION]，或告知使用者需要的操作。');
                 const observationText = observationLines.join('\n');
+                const canRetryFromGateFeedback = actionDepth < maxActionDepth;
 
                 // 透過 convoManager 注入 [System Observation]（讓 Golem 的下一輪能看到）
-                // 即使 allowActions=false，也應回灌給 Golem 讓其知道哪裡被擋；僅禁止再自動執行 action。
+                // ActionGate 回灌後允許進行修正重試（受 actionDepth/maxActionDepth 保護）。
                 if (controller && controller.convoManager) {
                     await controller.convoManager.enqueue(ctx, observationText, {
                         isPriority: true,
                         bypassDebounce: true,
                         isSystemFeedback: true,
                         suppressReply: true,
-                        allowActions: allowActions === true,
+                        allowActions: canRetryFromGateFeedback,
                         actionDepth: actionDepth + 1,
                         maxActionDepth,
                     });
@@ -375,9 +376,11 @@ class NeuroShunter {
                     try {
                         await brain.sendMessage(observationText, false, {
                             isSystemFeedback: true,
-                            allowActions: false,
+                            allowActions: canRetryFromGateFeedback,
                             disableToolRouting: true,
                             suppressReply: true,
+                            actionDepth: actionDepth + 1,
+                            maxActionDepth,
                         });
                     } catch (injectErr) {
                         console.warn(`[ActionGate] Failed to inject fallback observation to brain: ${injectErr.message}`);

--- a/src/managers/ActionExecutionGate.js
+++ b/src/managers/ActionExecutionGate.js
@@ -3,7 +3,7 @@ const SkillPackageRegistry = require('./SkillPackageRegistry');
 const { toolsetManager, SCENE_TOOLSETS } = require('./ToolsetManager');
 
 const BUILTIN_ACTIONS = new Set(['command', 'mcp_call', 'multi_agent', 'toolset']);
-const DEPRECATED_SCHEDULE_ACTIONS = new Set(['schedule', 'list-schedules']);
+const REMOVED_ACTIONS = new Set(['schedule', 'list-schedules']);
 
 function normalizeActionName(value) {
     return String(value || '')
@@ -122,11 +122,22 @@ class ActionExecutionGate {
             return { ok: true, lane: 'framework', normalizedAction };
         }
 
-        if (DEPRECATED_SCHEDULE_ACTIONS.has(normalizedAction)) {
+        if (REMOVED_ACTIONS.has(normalizedAction)) {
             return {
                 ok: false,
                 code: 'UNKNOWN_ACTION',
-                error: `Action "${normalizedAction}" has been deprecated. Please use "collab-calendar" instead. Example: {"action":"collab-calendar","args":{"action":"add","title":"明天 10:00 團隊同步","start":"2026-05-14T10:00:00+08:00","end":"2026-05-14T10:30:00+08:00"}}`,
+                error:
+                    `Action "${normalizedAction}" has been removed permanently and is no longer supported.\n` +
+                    `Use collab-calendar instead.\n` +
+                    `Example (this week): {"action":"collab-calendar","args":{"action":"upcoming","days":7}}\n` +
+                    `Sub-actions:\n` +
+                    `- list: list all events\n` +
+                    `- today: list today events\n` +
+                    `- upcoming: list next N days\n` +
+                    `- add: create event\n` +
+                    `- update: update event\n` +
+                    `- delete: delete event\n` +
+                    `- search: keyword search`,
             };
         }
 

--- a/src/managers/ToolRouter.js
+++ b/src/managers/ToolRouter.js
@@ -48,7 +48,7 @@ function inferIntentBoosts(text) {
     add(/(browser|chrome|devtools|網頁|頁面|點擊|輸入|表單|console|network|lighthouse|截圖|瀏覽器)/i, ['chrome-devtools']);
     add(/(git|commit|branch|diff|pull request|pr|版本|分支)/i, ['git']);
     add(/(記憶|memory|回憶|以前|之前|歷史|找對話|搜尋對話)/i, ['memory', 'session-search']);
-    add(/(排程|提醒|schedule|定時|每天|明天|下週|cron)/i, ['chronos', 'schedule', 'list-schedules']);
+    add(/(排程|提醒|schedule|定時|每天|明天|下週|cron)/i, ['chronos', 'collab-calendar']);
     add(/(行程|行事曆|日曆|calendar|今天有什麼|明天有什麼|這週|下週|新增行程|加入行程|排行程|有什麼約|約了什麼|協作日曆)/i, ['collab-calendar']);
     add(/(圖片|影像|畫圖|生成圖|image|prompt)/i, ['image-prompt']);
     add(/(youtube|影片|字幕)/i, ['youtube']);

--- a/src/managers/ToolsetManager.js
+++ b/src/managers/ToolsetManager.js
@@ -26,8 +26,8 @@ const ATOMIC_TOOLS = {
     mcp:     ['mcp'],
     // 社群整合
     social:  ['moltbot'],
-    // 生產力（日曆、排程）
-    productivity: ['collab-calendar', 'schedule', 'list-schedules'],
+    // 生產力（日曆）
+    productivity: ['collab-calendar'],
 };
 
 // ── 場景工具集（Scene Toolsets）────────────────────────────────────

--- a/web-dashboard/next.config.ts
+++ b/web-dashboard/next.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 // 讀取根目錄的 package.json 以獲取版本號
 const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf8"));
-const version = packageJson.version || "9.6.7";
+const version = packageJson.version || "9.6.8";
 const staticExportEnabled = process.env.NEXT_STATIC_EXPORT !== "false" && process.env.NODE_ENV === "production";
 
 const nextConfig: NextConfig = {

--- a/web-dashboard/routes/api.skills.js
+++ b/web-dashboard/routes/api.skills.js
@@ -6,6 +6,7 @@ const { ProtocolFormatter } = require('../../packages/protocol');
 const { buildOperationGuard } = require('../server/security');
 const { resolveActiveContext } = require('./utils/context');
 const SkillPackageRegistry = require('../../src/managers/SkillPackageRegistry');
+const REMOVED_SKILL_IDS = new Set(['schedule', 'list-schedules']);
 
 function extractSkillTitle(record) {
     const content = String(record.content || '');
@@ -28,6 +29,7 @@ function extractSkillTitle(record) {
 function normalizeSkillRecord(record, enabledSkills) {
     const id = String(record.id || '').trim().toLowerCase();
     if (!id) return null;
+    if (REMOVED_SKILL_IDS.has(id)) return null;
 
     const category = String(record.category || 'lib').trim().toLowerCase();
     const isDynamic = category === 'user_dynamic' || category === 'runtime' || category === 'runtime_user';
@@ -285,7 +287,8 @@ async function collectInstalledSkills(server, golemIdQuery) {
         }
     }
 
-    const skillsData = Array.from(skillsMap.values());
+    const skillsData = Array.from(skillsMap.values())
+        .filter((item) => !REMOVED_SKILL_IDS.has(String(item && item.id || '').toLowerCase()));
     skillsData.sort((a, b) => {
         if (a.isEnabled && !b.isEnabled) return -1;
         if (!a.isEnabled && b.isEnabled) return 1;

--- a/web-dashboard/src/components/GolemContext.tsx
+++ b/web-dashboard/src/components/GolemContext.tsx
@@ -46,7 +46,7 @@ const GolemContext = createContext<GolemContextType>({
     isBooting: false,
     isLoadingSystem: true,
     isSingleNode: true,
-    version: `v${process.env.NEXT_PUBLIC_GOLEM_VERSION || "9.6.7"}`,
+    version: `v${process.env.NEXT_PUBLIC_GOLEM_VERSION || "9.6.8"}`,
     allowRemote: false,
     localIp: "127.0.0.1",
     dashboardPort: 3000,
@@ -62,7 +62,7 @@ export function GolemProvider({ children }: { children: React.ReactNode }) {
     const [isBooting, setIsBooting] = useState(false);
     const [isLoadingSystem, setIsLoadingSystem] = useState(true);
     const [isSingleNode] = useState(true);
-    const [version, setVersion] = useState(`v${process.env.NEXT_PUBLIC_GOLEM_VERSION || "9.6.7"}`);
+    const [version, setVersion] = useState(`v${process.env.NEXT_PUBLIC_GOLEM_VERSION || "9.6.8"}`);
     const [allowRemote, setAllowRemote] = useState(false);
     const [localIp, setLocalIp] = useState("127.0.0.1");
     const [dashboardPort, setDashboardPort] = useState(3000);


### PR DESCRIPTION
V9.6.8 這次變更了什麼
共 10 個檔案：

版本號同步
package.json、README.md、docs/README.en.md、web-dashboard/next.config.ts、web-dashboard/src/components/GolemContext.tsx 都更新到 9.6.8
工具/技能執行鏈調整
packages/protocol/NeuroShunter.js
src/managers/ActionExecutionGate.js
src/managers/ToolRouter.js
src/managers/ToolsetManager.js
web-dashboard/routes/api.skills.js
這次改進了什麼（白話）
指令分流和 action 驗證更一致，降低「工具/技能被誤擋」機率
ToolRouter 與 Toolset 的銜接更穩，技能可用性判斷更清楚
api.skills 與版本顯示同步更新，前後端狀態更一致、比較不會混淆版本與可用功能