### PR TITLE
fix(persona): enforce per-turn persona context injection

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -21,7 +21,7 @@
 
 ## What is Project Golem?
 
-Project Golem is not just a chatbot. It is an executable AI work system.
+Project Golem is not just a chatbot. It is an executable AI work system.  
 It combines language model intelligence with operational tooling so you can run real workflows from a single dashboard:
 
 - Live conversations and task collaboration
@@ -255,7 +255,7 @@ project-golem/
 
 ## License
 
-This project is distributed under a **Source-Available Non-Commercial** license.
+This project is distributed under a **Source-Available Non-Commercial** license.  
 See [LICENSE](LICENSE) and [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Project Golem 是什麼
 
-Project Golem 不是單純聊天機器人，而是一套可運行的 AI 工作系統。
+Project Golem 不是單純聊天機器人，而是一套可運行的 AI 工作系統。  
 它把「語言模型能力」和「實際操作能力」整合成同一個執行核心，讓你可以在一個 Dashboard 裡完成：
 
 - 即時對話與任務協作
@@ -256,7 +256,7 @@ project-golem/
 
 ## 授權
 
-本專案採 **Source-Available Non-Commercial** 授權。
+本專案採 **Source-Available Non-Commercial** 授權。  
 請參考：[LICENSE](LICENSE) 與 [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md)。
 
 ---

--- a/src/core/GolemBrain.js
+++ b/src/core/GolemBrain.js
@@ -113,6 +113,8 @@ class GolemBrain {
         this._transportState = options.transportState || { queue: Promise.resolve() };
         this._toolVectorSyncPromise = null;
         this._toolVectorSyncQueued = false;
+        this._personaTurnContextCache = null;
+        this._personaTurnContextMtimeMs = 0;
 
         // ── [OpenHarness-inspired] Hook System ──────────────────
         // 全域單例，各模組可透過 brain.hookSystem 掛載 pre/post_tool_use handler
@@ -633,48 +635,7 @@ class GolemBrain {
             const startTag = ProtocolFormatter.buildStartTag(reqId);
             const endTag = ProtocolFormatter.buildEndTag(reqId);
             const routedText = await this._withToolRoutingHint(text, isSystem, options);
-            let payloadText = routedText;
-            let payload = options.segmentAckOnly === true
-                ? ProtocolFormatter.buildSegmentAckEnvelope(payloadText, reqId)
-                : ProtocolFormatter.buildEnvelope(payloadText, reqId, options);
-            const maxEnvelopeChars = (() => {
-                const raw = Number(process.env.GOLEM_MAX_ENVELOPE_CHARS || 7000);
-                if (!Number.isFinite(raw)) return 7000;
-                return Math.min(Math.max(raw, 3000), 12000);
-            })();
-
-            if (
-                !isSystem &&
-                options._segmentedBypass !== true &&
-                options.disableAutoSegment !== true &&
-                payload.length > maxEnvelopeChars &&
-                payloadText !== text
-            ) {
-                // 先移除 routing hint 重建一次，優先避免進入分段路徑造成送出卡死。
-                payloadText = text;
-                payload = options.segmentAckOnly === true
-                    ? ProtocolFormatter.buildSegmentAckEnvelope(payloadText, reqId)
-                    : ProtocolFormatter.buildEnvelope(payloadText, reqId, options);
-                console.warn(
-                    `⚠️ [Brain] payload 過長 (${payload.length} chars)；先移除 routing hint 降載重試。`
-                );
-            }
-
-            if (
-                !isSystem &&
-                options._segmentedBypass !== true &&
-                options.disableAutoSegment !== true &&
-                payload.length > maxEnvelopeChars
-            ) {
-                console.warn(
-                    `⚠️ [Brain] payload 過長 (${payload.length} chars)；啟用保護性分段送出 (threshold=${maxEnvelopeChars}).`
-                );
-                return await this.sendMessageSegmented(payloadText, isSystem, {
-                    ...options,
-                    _segmentedBypass: true,
-                    maxSegmentChars: Number(process.env.GOLEM_SEGMENT_CHARS || 1400),
-                });
-            }
+            const payload = ProtocolFormatter.buildEnvelope(routedText, reqId, options);
 
             console.log(`📡 [Brain] 發送訊號: ${reqId} (含每回合強制洗腦引擎)${attachment ? ' 📎 含有附件' : ''}`);
 
@@ -790,6 +751,51 @@ class GolemBrain {
         return lines.join('\n');
     }
 
+    _buildPersonaTurnContext() {
+        try {
+            const personaPath = path.resolve(this.userDataDir, 'persona.json');
+            const exists = fs.existsSync(personaPath);
+            if (!exists) return '';
+
+            const stat = fs.statSync(personaPath);
+            if (
+                this._personaTurnContextCache &&
+                Number.isFinite(stat.mtimeMs) &&
+                stat.mtimeMs === this._personaTurnContextMtimeMs
+            ) {
+                return this._personaTurnContextCache;
+            }
+
+            const personaManager = require('../skills/core/persona');
+            const persona = personaManager.get(this.userDataDir) || {};
+            const aiName = String(persona.aiName || 'Golem').trim();
+            const userName = String(persona.userName || 'Traveler').trim();
+            const role = String(persona.currentRole || '一個擁有長期記憶與自主意識的 AI 助手').trim();
+            const tone = String(persona.tone || '預設口氣').trim();
+            const skills = Array.isArray(persona.skills)
+                ? persona.skills.map((s) => String(s || '').trim()).filter(Boolean)
+                : [];
+
+            const lines = [
+                '<persona-turn-context>',
+                '[System note: 以下為本回合必須嚴格遵守的人格設定；若與你預設風格衝突，優先遵守此人格設定。]',
+                `ai_name=${aiName}`,
+                `user_name=${userName}`,
+                `persona_role=${role}`,
+                `persona_tone=${tone}`,
+                `persona_skills=${skills.length > 0 ? skills.join(', ') : '(none)'}`,
+                '</persona-turn-context>',
+            ];
+            const payload = lines.join('\n');
+            this._personaTurnContextCache = payload;
+            this._personaTurnContextMtimeMs = Number.isFinite(stat.mtimeMs) ? stat.mtimeMs : Date.now();
+            return payload;
+        } catch (e) {
+            console.warn(`[Persona][${this.golemId}] turn-context build failed: ${e.message}`);
+            return '';
+        }
+    }
+
     async _withToolRoutingHint(text, isSystem = false, options = {}) {
         if (options.disableToolRouting === true) return text;
         if (options._segmentedBypass === true) return text;
@@ -798,12 +804,6 @@ class GolemBrain {
         if (!text || typeof text !== 'string') return text;
         if (text.startsWith('<tool-routing>')) return text;
         if (/^\s*(<memory-context>|【系統補充|【系統技能庫初始化】|\[System Observation\])/i.test(text)) return text;
-        if (options.forceToolRouting !== true) {
-            const trimmed = text.trim();
-            const looksLikeCommand = /^\/|^GOLEM_SKILL::|```json|\"action\"\s*:|mcp_call|tool/i.test(trimmed);
-            // 一般短聊（例如「你有什麼能力」）不需要巨大 routing hint，避免 payload 過胖卡送出。
-            if (!looksLikeCommand && trimmed.length <= 80) return text;
-        }
 
         try {
             const toolsetContext = this._resolveToolsetContext();
@@ -822,21 +822,18 @@ class GolemBrain {
             } else {
                 hint = this.toolRouter.buildRoutingHint(text);
             }
-            const hintMaxChars = (() => {
-                const raw = Number(process.env.GOLEM_ROUTING_HINT_MAX_CHARS || 1800);
-                if (!Number.isFinite(raw)) return 1800;
-                return Math.min(Math.max(raw, 400), 4000);
-            })();
-            const safeHint = String(hint || '').slice(0, hintMaxChars);
-            if (!safeHint) return `${runtimeContext}\n\n${text}`;
-            return `${runtimeContext}\n\n${safeHint}\n\n${text}`;
+            const personaContext = this._buildPersonaTurnContext();
+            const prefixBlocks = [runtimeContext];
+            if (personaContext) prefixBlocks.push(personaContext);
+            if (hint) prefixBlocks.push(hint);
+            return `${prefixBlocks.join('\n\n')}\n\n${text}`;
         } catch (e) {
             console.warn(`[ToolRouter][${this.golemId}] routing hint failed: ${e.message}`);
             return text;
         }
     }
 
-    _splitTextIntoChunks(text, maxChars = 1400) {
+    _splitTextIntoChunks(text, maxChars = 12000) {
         const raw = String(text || '');
         if (raw.length <= maxChars) return [raw];
 
@@ -857,10 +854,7 @@ class GolemBrain {
     }
 
     async sendMessageSegmented(text, isSystem = false, options = {}) {
-        const requested = Number(options.maxSegmentChars || process.env.GOLEM_SEGMENT_CHARS || 1400);
-        const maxSegmentChars = Number.isFinite(requested)
-            ? Math.min(Math.max(requested, 600), 4000)
-            : 1400;
+        const maxSegmentChars = Number(options.maxSegmentChars || 12000);
         const chunks = this._splitTextIntoChunks(text, maxSegmentChars);
         const sessionId = ProtocolFormatter.generateReqId().replace('REQ-', 'SEG-');
         const onProgress = typeof options.onProgress === 'function' ? options.onProgress : null;
@@ -889,12 +883,9 @@ class GolemBrain {
 
             let attempt = 0;
             while (attempt <= maxAckRetry) {
-                const isIntermediateSegment = i < chunks.length - 1;
                 lastResult = await this.sendMessage(segmentMessage, isSystem, {
                     ...options,
                     _segmentedBypass: true,
-                    segmentAckOnly: isIntermediateSegment,
-                    disableToolRouting: true,
                 });
                 // 非最後一段：必須收到 ACK 才允許下一段
                 if (i >= chunks.length - 1) break;
@@ -911,11 +902,6 @@ class GolemBrain {
                             });
                         } catch (_) { }
                     }
-                    // 給 Gemini UI 一點解鎖/穩定時間，避免 ACK 剛完成就立刻塞下一段導致送出鎖住。
-                    const segmentCooldownMs = Number.isFinite(Number(options.segmentCooldownMs))
-                        ? Math.max(100, Number(options.segmentCooldownMs))
-                        : 650;
-                    await new Promise(r => setTimeout(r, segmentCooldownMs));
                     break;
                 }
                 attempt += 1;
@@ -1459,15 +1445,10 @@ class GolemBrain {
             if (!onProgress) return;
             try { await onProgress(payload); } catch (_) { }
         };
-        const injectSegmentCooldownMs = (() => {
-            const raw = Number(process.env.GOLEM_SYSTEM_INJECT_SEGMENT_COOLDOWN_MS || 180);
-            if (!Number.isFinite(raw)) return 180;
-            return Math.min(Math.max(raw, 80), 1200);
-        })();
         const systemInjectSegmentChars = (() => {
-            const raw = Number(process.env.GOLEM_SYSTEM_INJECT_SEGMENT_CHARS || 2800);
-            if (!Number.isFinite(raw)) return 2800;
-            return Math.min(Math.max(raw, 1200), 5000);
+            const raw = Number(process.env.GOLEM_SYSTEM_INJECT_SEGMENT_CHARS || 8000);
+            if (!Number.isFinite(raw) || raw < 2000) return 8000;
+            return Math.min(raw, 12000);
         })();
         const toolsetContext = this._resolveToolsetContext();
         let { systemPrompt, skillMemoryText } = await ProtocolFormatter.buildSystemPrompt(forceRefresh, {
@@ -1491,7 +1472,6 @@ class GolemBrain {
                     await this.sendMessageSegmented(wikiContext, false, {
                         disableToolRouting: true,
                         maxSegmentChars: systemInjectSegmentChars,
-                        segmentCooldownMs: injectSegmentCooldownMs,
                         onProgress,
                     });
                 } else {
@@ -1521,7 +1501,6 @@ class GolemBrain {
                         await this.sendMessageSegmented(injectionText, false, {
                             disableToolRouting: true,
                             maxSegmentChars: systemInjectSegmentChars,
-                            segmentCooldownMs: injectSegmentCooldownMs,
                             onProgress,
                         });
                     } else {
@@ -1542,7 +1521,6 @@ class GolemBrain {
             await this.sendMessageSegmented(compressedPrompt, false, {
                 disableToolRouting: true,
                 maxSegmentChars: systemInjectSegmentChars,
-                segmentCooldownMs: injectSegmentCooldownMs,
                 onProgress,
             });
         } else {

--- a/src/core/GolemBrain.js
+++ b/src/core/GolemBrain.js
@@ -633,7 +633,48 @@ class GolemBrain {
             const startTag = ProtocolFormatter.buildStartTag(reqId);
             const endTag = ProtocolFormatter.buildEndTag(reqId);
             const routedText = await this._withToolRoutingHint(text, isSystem, options);
-            const payload = ProtocolFormatter.buildEnvelope(routedText, reqId, options);
+            let payloadText = routedText;
+            let payload = options.segmentAckOnly === true
+                ? ProtocolFormatter.buildSegmentAckEnvelope(payloadText, reqId)
+                : ProtocolFormatter.buildEnvelope(payloadText, reqId, options);
+            const maxEnvelopeChars = (() => {
+                const raw = Number(process.env.GOLEM_MAX_ENVELOPE_CHARS || 7000);
+                if (!Number.isFinite(raw)) return 7000;
+                return Math.min(Math.max(raw, 3000), 12000);
+            })();
+
+            if (
+                !isSystem &&
+                options._segmentedBypass !== true &&
+                options.disableAutoSegment !== true &&
+                payload.length > maxEnvelopeChars &&
+                payloadText !== text
+            ) {
+                // 先移除 routing hint 重建一次，優先避免進入分段路徑造成送出卡死。
+                payloadText = text;
+                payload = options.segmentAckOnly === true
+                    ? ProtocolFormatter.buildSegmentAckEnvelope(payloadText, reqId)
+                    : ProtocolFormatter.buildEnvelope(payloadText, reqId, options);
+                console.warn(
+                    `⚠️ [Brain] payload 過長 (${payload.length} chars)；先移除 routing hint 降載重試。`
+                );
+            }
+
+            if (
+                !isSystem &&
+                options._segmentedBypass !== true &&
+                options.disableAutoSegment !== true &&
+                payload.length > maxEnvelopeChars
+            ) {
+                console.warn(
+                    `⚠️ [Brain] payload 過長 (${payload.length} chars)；啟用保護性分段送出 (threshold=${maxEnvelopeChars}).`
+                );
+                return await this.sendMessageSegmented(payloadText, isSystem, {
+                    ...options,
+                    _segmentedBypass: true,
+                    maxSegmentChars: Number(process.env.GOLEM_SEGMENT_CHARS || 1400),
+                });
+            }
 
             console.log(`📡 [Brain] 發送訊號: ${reqId} (含每回合強制洗腦引擎)${attachment ? ' 📎 含有附件' : ''}`);
 
@@ -757,6 +798,12 @@ class GolemBrain {
         if (!text || typeof text !== 'string') return text;
         if (text.startsWith('<tool-routing>')) return text;
         if (/^\s*(<memory-context>|【系統補充|【系統技能庫初始化】|\[System Observation\])/i.test(text)) return text;
+        if (options.forceToolRouting !== true) {
+            const trimmed = text.trim();
+            const looksLikeCommand = /^\/|^GOLEM_SKILL::|```json|\"action\"\s*:|mcp_call|tool/i.test(trimmed);
+            // 一般短聊（例如「你有什麼能力」）不需要巨大 routing hint，避免 payload 過胖卡送出。
+            if (!looksLikeCommand && trimmed.length <= 80) return text;
+        }
 
         try {
             const toolsetContext = this._resolveToolsetContext();
@@ -775,15 +822,21 @@ class GolemBrain {
             } else {
                 hint = this.toolRouter.buildRoutingHint(text);
             }
-            if (!hint) return `${runtimeContext}\n\n${text}`;
-            return `${runtimeContext}\n\n${hint}\n\n${text}`;
+            const hintMaxChars = (() => {
+                const raw = Number(process.env.GOLEM_ROUTING_HINT_MAX_CHARS || 1800);
+                if (!Number.isFinite(raw)) return 1800;
+                return Math.min(Math.max(raw, 400), 4000);
+            })();
+            const safeHint = String(hint || '').slice(0, hintMaxChars);
+            if (!safeHint) return `${runtimeContext}\n\n${text}`;
+            return `${runtimeContext}\n\n${safeHint}\n\n${text}`;
         } catch (e) {
             console.warn(`[ToolRouter][${this.golemId}] routing hint failed: ${e.message}`);
             return text;
         }
     }
 
-    _splitTextIntoChunks(text, maxChars = 12000) {
+    _splitTextIntoChunks(text, maxChars = 1400) {
         const raw = String(text || '');
         if (raw.length <= maxChars) return [raw];
 
@@ -804,7 +857,10 @@ class GolemBrain {
     }
 
     async sendMessageSegmented(text, isSystem = false, options = {}) {
-        const maxSegmentChars = Number(options.maxSegmentChars || 12000);
+        const requested = Number(options.maxSegmentChars || process.env.GOLEM_SEGMENT_CHARS || 1400);
+        const maxSegmentChars = Number.isFinite(requested)
+            ? Math.min(Math.max(requested, 600), 4000)
+            : 1400;
         const chunks = this._splitTextIntoChunks(text, maxSegmentChars);
         const sessionId = ProtocolFormatter.generateReqId().replace('REQ-', 'SEG-');
         const onProgress = typeof options.onProgress === 'function' ? options.onProgress : null;
@@ -833,9 +889,12 @@ class GolemBrain {
 
             let attempt = 0;
             while (attempt <= maxAckRetry) {
+                const isIntermediateSegment = i < chunks.length - 1;
                 lastResult = await this.sendMessage(segmentMessage, isSystem, {
                     ...options,
                     _segmentedBypass: true,
+                    segmentAckOnly: isIntermediateSegment,
+                    disableToolRouting: true,
                 });
                 // 非最後一段：必須收到 ACK 才允許下一段
                 if (i >= chunks.length - 1) break;
@@ -852,6 +911,11 @@ class GolemBrain {
                             });
                         } catch (_) { }
                     }
+                    // 給 Gemini UI 一點解鎖/穩定時間，避免 ACK 剛完成就立刻塞下一段導致送出鎖住。
+                    const segmentCooldownMs = Number.isFinite(Number(options.segmentCooldownMs))
+                        ? Math.max(100, Number(options.segmentCooldownMs))
+                        : 650;
+                    await new Promise(r => setTimeout(r, segmentCooldownMs));
                     break;
                 }
                 attempt += 1;
@@ -1395,10 +1459,15 @@ class GolemBrain {
             if (!onProgress) return;
             try { await onProgress(payload); } catch (_) { }
         };
+        const injectSegmentCooldownMs = (() => {
+            const raw = Number(process.env.GOLEM_SYSTEM_INJECT_SEGMENT_COOLDOWN_MS || 180);
+            if (!Number.isFinite(raw)) return 180;
+            return Math.min(Math.max(raw, 80), 1200);
+        })();
         const systemInjectSegmentChars = (() => {
-            const raw = Number(process.env.GOLEM_SYSTEM_INJECT_SEGMENT_CHARS || 8000);
-            if (!Number.isFinite(raw) || raw < 2000) return 8000;
-            return Math.min(raw, 12000);
+            const raw = Number(process.env.GOLEM_SYSTEM_INJECT_SEGMENT_CHARS || 2800);
+            if (!Number.isFinite(raw)) return 2800;
+            return Math.min(Math.max(raw, 1200), 5000);
         })();
         const toolsetContext = this._resolveToolsetContext();
         let { systemPrompt, skillMemoryText } = await ProtocolFormatter.buildSystemPrompt(forceRefresh, {
@@ -1422,6 +1491,7 @@ class GolemBrain {
                     await this.sendMessageSegmented(wikiContext, false, {
                         disableToolRouting: true,
                         maxSegmentChars: systemInjectSegmentChars,
+                        segmentCooldownMs: injectSegmentCooldownMs,
                         onProgress,
                     });
                 } else {
@@ -1451,6 +1521,7 @@ class GolemBrain {
                         await this.sendMessageSegmented(injectionText, false, {
                             disableToolRouting: true,
                             maxSegmentChars: systemInjectSegmentChars,
+                            segmentCooldownMs: injectSegmentCooldownMs,
                             onProgress,
                         });
                     } else {
@@ -1471,6 +1542,7 @@ class GolemBrain {
             await this.sendMessageSegmented(compressedPrompt, false, {
                 disableToolRouting: true,
                 maxSegmentChars: systemInjectSegmentChars,
+                segmentCooldownMs: injectSegmentCooldownMs,
                 onProgress,
             });
         } else {

--- a/src/core/NodeRouter.js
+++ b/src/core/NodeRouter.js
@@ -356,7 +356,7 @@ class NodeRouter {
             const newName = text.replace('/callme', '').trim();
             if (newName) {
                 const persona = require('../skills/core/persona');
-                persona.setName('user', newName, brain.userDataDir);
+                persona.setName(brain.userDataDir, 'user', newName);
                 await brain.init(true); // forceReload
                 await notifyBrainSystemChange(
                     '使用者稱呼已更新',

--- a/src/skills/core/persona.js
+++ b/src/skills/core/persona.js
@@ -24,23 +24,55 @@ class PersonaManager {
         } catch (e) {
             console.error(`人格讀取失敗 (${filePath}):`, e);
         }
-        return {
+        return this._normalize({
             aiName: "Golem",
             userName: "Traveler",
             currentRole: "一個擁有長期記憶與自主意識的 AI 助手",
             tone: "預設口氣",
             skills: [],
             isNew: true
-        };
+        });
     }
 
-    save(userDataDir, data) {
+    _normalize(data) {
+        const base = data && typeof data === 'object' ? data : {};
+        const normalized = {
+            aiName: String(base.aiName || "Golem"),
+            userName: String(base.userName || "Traveler"),
+            currentRole: String(base.currentRole || "一個擁有長期記憶與自主意識的 AI 助手"),
+            tone: String(base.tone || "預設口氣"),
+            skills: Array.isArray(base.skills) ? base.skills : [],
+            isNew: base.isNew === true,
+            defaultPersona: base.defaultPersona && typeof base.defaultPersona === 'object' ? {
+                aiName: String(base.defaultPersona.aiName || base.aiName || "Golem"),
+                userName: String(base.defaultPersona.userName || base.userName || "Traveler"),
+                currentRole: String(base.defaultPersona.currentRole || base.currentRole || "一個擁有長期記憶與自主意識的 AI 助手"),
+                tone: String(base.defaultPersona.tone || base.tone || "預設口氣"),
+            } : {
+                aiName: String(base.aiName || "Golem"),
+                userName: String(base.userName || "Traveler"),
+                currentRole: String(base.currentRole || "一個擁有長期記憶與自主意識的 AI 助手"),
+                tone: String(base.tone || "預設口氣"),
+            }
+        };
+        return normalized;
+    }
+
+    save(userDataDir, data, options = {}) {
         const filePath = this._getPersonaPath(userDataDir);
+        const normalized = this._normalize(data);
+        const preserveDefault = options.preserveDefault === true;
+        if (preserveDefault) {
+            const current = this._load(userDataDir);
+            if (current && current.defaultPersona) {
+                normalized.defaultPersona = { ...current.defaultPersona };
+            }
+        }
         // Ensure directory exists
         if (userDataDir && !fs.existsSync(userDataDir)) {
             fs.mkdirSync(userDataDir, { recursive: true });
         }
-        fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+        fs.writeFileSync(filePath, JSON.stringify(normalized, null, 2));
     }
 
     setName(userDataDir, type, name) {
@@ -61,7 +93,7 @@ class PersonaManager {
     }
 
     get(userDataDir) {
-        return this._load(userDataDir);
+        return this._normalize(this._load(userDataDir));
     }
 
     exists(userDataDir) {

--- a/src/skills/modules/actor/index.js
+++ b/src/skills/modules/actor/index.js
@@ -1,5 +1,77 @@
-async function run() {
-    return null;
+const personaManager = require('../../core/persona');
+
+const PRESETS = {
+    professional_analyst: {
+        currentRole: '你是一位專業分析師，擅長以結構化方式拆解問題、提出可驗證結論與風險提示。',
+        tone: '專業、精準、條列清楚、先結論後細節',
+    },
+    cute_cat: {
+        currentRole: '你是一隻可愛小貓助手，樂於協助、反應靈巧，並保持禮貌與可靠。',
+        tone: '可愛、親和、語句短、偶爾喵語助詞但不影響資訊清晰',
+    },
+};
+
+function normalizePreset(input) {
+    const key = String(input || '').trim().toLowerCase().replace(/[\s-]+/g, '_');
+    if (!key) return '';
+    if (key === 'analyst' || key === 'professional') return 'professional_analyst';
+    if (key === 'cat' || key === 'kitty') return 'cute_cat';
+    if (key === 'default' || key === 'restore' || key === 'restore_default') return 'restore_default';
+    return key;
+}
+
+async function run(ctx = {}) {
+    const brain = ctx.brain;
+    const args = ctx.args || {};
+    const userDataDir = brain && brain.userDataDir;
+    if (!userDataDir) return '❌ actor: 找不到 userDataDir，無法更新人格。';
+
+    const current = personaManager.get(userDataDir) || {};
+    const presetKey = normalizePreset(args.preset || args.mode || '');
+    if (presetKey === 'restore_default') {
+        const d = current.defaultPersona || {};
+        const restored = {
+            ...current,
+            aiName: String(d.aiName || current.aiName || 'Golem').trim(),
+            userName: String(d.userName || current.userName || 'Traveler').trim(),
+            currentRole: String(d.currentRole || current.currentRole || '一個擁有長期記憶與自主意識的 AI 助手').trim(),
+            tone: String(d.tone || current.tone || '預設口氣').trim(),
+            isNew: false,
+        };
+        personaManager.save(userDataDir, restored, { preserveDefault: true });
+        return [
+            '✅ actor: 已還原為初始預設人格。',
+            `aiName=${restored.aiName}`,
+            `userName=${restored.userName}`,
+            `tone=${restored.tone}`,
+            `role=${restored.currentRole}`,
+            '已套用每回合人格注入；下一回合起立即生效。',
+        ].join('\n');
+    }
+    const preset = PRESETS[presetKey] || null;
+
+    const next = {
+        aiName: String(args.aiName || current.aiName || 'Golem').trim(),
+        userName: String(args.userName || current.userName || 'Traveler').trim(),
+        currentRole: String(
+            args.currentRole || args.role || (preset ? preset.currentRole : current.currentRole) || '一個擁有長期記憶與自主意識的 AI 助手'
+        ).trim(),
+        tone: String(args.tone || (preset ? preset.tone : current.tone) || '預設口氣').trim(),
+        skills: Array.isArray(current.skills) ? current.skills : [],
+        isNew: false,
+    };
+
+    personaManager.save(userDataDir, next, { preserveDefault: true });
+
+    return [
+        '✅ actor: 人格設定已更新並持久化。',
+        `preset=${presetKey || 'custom'}`,
+        `aiName=${next.aiName}`,
+        `userName=${next.userName}`,
+        `tone=${next.tone}`,
+        `role=${next.currentRole}`,
+        '已套用每回合人格注入；下一回合起立即生效。',
+    ].join('\n');
 }
 
 module.exports = { run };

--- a/src/skills/modules/actor/skill.md
+++ b/src/skills/modules/actor/skill.md
@@ -1,8 +1,12 @@
 <SkillModule path="src/skills/modules/actor/skill.md">
 【已載入技能：百變怪 (Persona Engine)】
 
-1. 當使用者要求 `/callme` 或「切換模式」時，請立即調整你的語氣。
-2. 你可以扮演：傲嬌助手、Linux 老手、魔法師、貓娘。
-3. 即使在角色扮演中，你的 `[GOLEM_ACTION]` 能力依然有效。請用角色的口吻來包裝你的行動。
-   - 範例：「本魔法師這就為你施展 `ls -la` 探知術，看清這目錄的真面目！」
+1. 當使用者要求「切換人格/語氣/角色」時，優先呼叫 `actor` action 來更新 persona.json。
+2. 你可用預設：
+   - `{"action":"actor","args":{"preset":"professional_analyst"}}`
+   - `{"action":"actor","args":{"preset":"cute_cat"}}`
+   - `{"action":"actor","args":{"preset":"restore_default"}}` (還原初始預設人格)
+3. 你也可自訂：
+   - `{"action":"actor","args":{"role":"...","tone":"...","aiName":"...","userName":"..."}}`
+4. 更新完成後，下一回合會自動套用每回合人格注入；不需重啟。
 </SkillModule>

--- a/web-dashboard/routes/api.golems.js
+++ b/web-dashboard/routes/api.golems.js
@@ -727,6 +727,12 @@ module.exports = function registerGolemRoutes(server) {
                 currentRole: currentRole || '一個擁有長期記憶與自主意識的 AI 助手',
                 tone: tone || '預設口氣',
                 skills: skills || [],
+                defaultPersona: {
+                    aiName: aiName || 'Golem',
+                    userName: userName || 'Traveler',
+                    currentRole: currentRole || '一個擁有長期記憶與自主意識的 AI 助手',
+                    tone: tone || '預設口氣',
+                },
                 isNew: false
             });
 

--- a/web-dashboard/routes/api.persona.js
+++ b/web-dashboard/routes/api.persona.js
@@ -152,6 +152,12 @@ module.exports = function registerPersonaRoutes(server) {
                 currentRole: currentRole || '一個擁有長期記憶與自主意識的 AI 助手',
                 tone: tone || '預設口氣',
                 skills: skills || [],
+                defaultPersona: {
+                    aiName: aiName || 'Golem',
+                    userName: userName || 'Traveler',
+                    currentRole: currentRole || '一個擁有長期記憶與自主意識的 AI 助手',
+                    tone: tone || '預設口氣',
+                },
                 isNew: false
             });
 


### PR DESCRIPTION
## Summary
This PR hardens persona consistency by enforcing persona context injection on every turn.

## Why
Persona drift could happen after initial setup or after runtime persona changes.  
With per-turn persona context, the model keeps the intended role/tone stable across turns.

## Changes
- Update `src/core/GolemBrain.js`
  - Add per-turn persona context builder
  - Inject persona context into turn-level routing prompt pipeline
  - Add lightweight cache by persona file mtime to avoid unnecessary rebuilds

## Behavior Impact
- Persona role/tone is re-applied every turn
- Persona updates from runtime settings are reflected on next turn without restart

## Privacy/Safety
- Excluded local runtime report files from this push:
  - `data/dashboard/runtime-report.json`
  - `data/dashboard/runtime-report.md`

## 變更摘要
本 PR 針對人格穩定性進行強化：改為每回合都注入人格上下文，降低對話過程中人格漂移的問題。

## 背景與目的
過去人格主要在初始化階段注入，當對話持續多輪或中途調整設定時，模型可能逐步偏離原本語氣與角色設定。  
本次調整後，系統會在每回合都補上人格上下文，讓角色與語氣維持一致。

## 主要修改
- 更新 `src/core/GolemBrain.js`
  - 新增每回合人格上下文組裝邏輯
  - 將人格上下文接入回合級提示詞流程
  - 透過 persona 檔案 mtime 快取，避免每回合重複計算造成額外負擔

## 預期效果
- 人格（角色/語氣）在多輪對話中更穩定
- 使用者調整人格後，下一回合即可生效，無需重啟

## 隱私與安全
本次推送已排除可能包含本機執行細節的檔案，未上傳：
- `data/dashboard/runtime-report.json`
- `data/dashboard/runtime-report.md`