### PR TITLE
feat: release v9.7.5 with market decision updates

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,7 +4,7 @@
   <p><strong>Your AI operations hub: chat, act, remember, and collaborate over the long run.</strong></p>
 
   <p>
-    <img src="https://img.shields.io/badge/version-9.7.2-blue?style=for-the-badge" alt="version" />
+    <img src="https://img.shields.io/badge/version-9.7.5-blue?style=for-the-badge" alt="version" />
     <img src="https://img.shields.io/badge/node.js-20~22-3C873A?style=for-the-badge&logo=nodedotjs&logoColor=white" alt="node" />
     <img src="https://img.shields.io/badge/backend-gemini%20web%20%7C%20ollama%20%7C%20lmstudio-orange?style=for-the-badge" alt="backend" />
     <img src="https://img.shields.io/badge/dashboard-next.js-black?style=for-the-badge&logo=nextdotjs" alt="dashboard" />

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p><strong>你的 AI 操作中樞：可對話、可行動、可記憶、可長期協作。</strong></p>
 
   <p>
-    <img src="https://img.shields.io/badge/version-9.7.2-blue?style=for-the-badge" alt="version" />
+    <img src="https://img.shields.io/badge/version-9.7.5-blue?style=for-the-badge" alt="version" />
     <img src="https://img.shields.io/badge/node.js-20~22-3C873A?style=for-the-badge&logo=nodedotjs&logoColor=white" alt="node" />
     <img src="https://img.shields.io/badge/backend-gemini%20web%20%7C%20ollama%20%7C%20lmstudio-orange?style=for-the-badge" alt="backend" />
     <img src="https://img.shields.io/badge/dashboard-next.js-black?style=for-the-badge&logo=nextdotjs" alt="dashboard" />

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -4,7 +4,7 @@
   <p><b>Ultimate Chronos + MultiAgent + Social Node Edition</b></p>
 
   <p>
-    <img src="https://img.shields.io/badge/Version-9.7.2-blue?style=for-the-badge" alt="Version">
+    <img src="https://img.shields.io/badge/Version-9.7.5-blue?style=for-the-badge" alt="Version">
     <img src="https://img.shields.io/badge/Engine-Node.js%2020-green?style=for-the-badge&logo=nodedotjs" alt="Engine">
     <img src="https://img.shields.io/badge/Brain-Gemini%20Web%20%7C%20Ollama-orange?style=for-the-badge&logo=google" alt="Brain">
     <img src="https://img.shields.io/badge/Platform-Telegram%20%7C%20Discord-blue?style=for-the-badge" alt="Platform">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-golem",
-  "version": "9.7.2",
+  "version": "9.7.5",
   "description": "Project Golem v9.5 (Ultimate Chronos + MultiAgent Edition) - Collaborative AI System",
   "main": "index.js",
   "scripts": {

--- a/src/managers/ChatLogManager.js
+++ b/src/managers/ChatLogManager.js
@@ -5,6 +5,10 @@ const { LOG_RETENTION_MS, MEMORY_TIERS } = require('../core/constants');
 const ResponseParser = require('../utils/ResponseParser');
 const TrajectoryCompressor = require('./TrajectoryCompressor');
 
+const DAILY_COMPRESSION_LARGE_PAYLOAD_CHARS = 30000;
+const DAILY_COMPRESSION_RESPONSE_TIMEOUT_MS = 8 * 60 * 1000;
+const DAILY_COMPRESSION_CHUNK_TARGET_CHARS = 12000;
+
 let sqlite3Instance = null;
 
 function getSqlite3() {
@@ -353,8 +357,7 @@ class ChatLogManager {
         const totalChars = combinedContent.length;
         console.log(`🤖 [LogManager] 待壓縮對話計 ${messages.length} 條，總字數 ${totalChars}。請求 Gemini...`);
         
-        const prompt = `【系統指令：對話回顧與壓縮】\n以下是 ${dateString} 的對話記錄。請整理成約 ${MEMORY_TIERS.DAILY_SUMMARY_CHARS} 字的精煉摘要，保留重要決策、進度與細節：\n\n${combinedContent}`;
-        await this._compressAndSave(prompt, dateString, 'daily', brain, totalChars);
+        await this._compressDailyByChunks(dateString, combinedContent, brain, totalChars);
     }
 
     // ============================================================
@@ -439,24 +442,91 @@ class ChatLogManager {
         await this._compressAndSave(prompt, decadeString, 'era', brain, combinedContent.length);
     }
 
-    async _compressAndSave(prompt, dateString, tier, brain, originalSize = 0) {
+    _splitDailyContent(content, targetChars = DAILY_COMPRESSION_CHUNK_TARGET_CHARS) {
+        const text = String(content || '');
+        if (!text) return [];
+        if (text.length <= targetChars) return [text];
+
+        const chunks = [];
+        let cursor = 0;
+        while (cursor < text.length) {
+            let next = Math.min(cursor + targetChars, text.length);
+            if (next < text.length) {
+                const lastBreak = text.lastIndexOf('\n', next);
+                if (lastBreak > cursor + Math.floor(targetChars * 0.5)) {
+                    next = lastBreak + 1;
+                }
+            }
+            chunks.push(text.slice(cursor, next));
+            cursor = next;
+        }
+        return chunks.filter(Boolean);
+    }
+
+    async _compressDailyByChunks(dateString, combinedContent, brain, originalSize = 0) {
         const startTime = Date.now();
         try {
-            const rawResponse = await brain.sendMessage(prompt, false);
+            const chunks = this._splitDailyContent(combinedContent, DAILY_COMPRESSION_CHUNK_TARGET_CHARS);
+            console.log(`🧩 [LogManager] ${dateString} daily 分段摘要模式：${chunks.length} 段（原文 ${originalSize} chars）。`);
+            if (originalSize >= DAILY_COMPRESSION_LARGE_PAYLOAD_CHARS) {
+                console.log(`⏱️ [LogManager] ${dateString} daily 大 payload，分段與合併步驟均使用 ${Math.round(DAILY_COMPRESSION_RESPONSE_TIMEOUT_MS / 1000)}s 等待上限。`);
+            }
+
+            const chunkSummaries = [];
+            for (let index = 0; index < chunks.length; index += 1) {
+                const chunk = chunks[index];
+                const chunkPrompt = `【系統指令：Daily 分段摘要 (${index + 1}/${chunks.length})】\n以下是 ${dateString} 對話片段，請先產出精煉摘要，聚焦重要決策、進度、阻塞、待辦與風險（約 350-600 字）：\n\n${chunk}`;
+                const rawResponse = await brain.sendMessage(chunkPrompt, false, {
+                    responseTimeoutMs: DAILY_COMPRESSION_RESPONSE_TIMEOUT_MS
+                });
+                const parsed = ResponseParser.parse(rawResponse);
+                const summaryText = String(parsed.reply || '').trim();
+                if (!summaryText) {
+                    throw new Error(`daily chunk ${index + 1}/${chunks.length} 摘要為空`);
+                }
+                chunkSummaries.push(`--- Chunk ${index + 1}/${chunks.length} ---\n${summaryText}`);
+            }
+
+            const mergePrompt = `【系統指令：Daily 摘要最終合併】\n以下是 ${dateString} 各分段摘要，請合併成一份約 ${MEMORY_TIERS.DAILY_SUMMARY_CHARS} 字的精煉 daily 摘要，保留關鍵決策、進度、細節、風險與下一步：\n\n${chunkSummaries.join('\n\n')}`;
+            const mergedResponse = await brain.sendMessage(mergePrompt, false, {
+                responseTimeoutMs: DAILY_COMPRESSION_RESPONSE_TIMEOUT_MS
+            });
+            const mergedParsed = ResponseParser.parse(mergedResponse);
+            const finalSummary = String(mergedParsed.reply || '').trim();
+            if (!finalSummary) {
+                throw new Error('daily 分段合併摘要為空');
+            }
+
+            await this._insertSummary('daily', dateString, finalSummary, originalSize);
+            const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+            console.log(`✅ [LogManager] ${dateString} daily 產出成功！(耗時: ${duration}s, 摘要: ${finalSummary.length}字, 分段: ${chunks.length})`);
+        } catch (e) {
+            console.error(`❌ [LogManager] daily 分段生成失敗 (${dateString}):`, e.message);
+        }
+    }
+
+    async _insertSummary(tier, dateString, summaryText, originalSize = 0) {
+        await this.runAsync(
+            `INSERT INTO summaries (tier, date_string, timestamp, content, original_size, summary_size) 
+             VALUES (?, ?, ?, ?, ?, ?)`,
+            [tier, dateString, Date.now(), summaryText, originalSize, summaryText.length]
+        );
+    }
+
+    async _compressAndSave(prompt, dateString, tier, brain, originalSize = 0, sendOptions = {}) {
+        const startTime = Date.now();
+        try {
+            if (tier === 'daily' && Number.isFinite(sendOptions.responseTimeoutMs)) {
+                console.log(`⏱️ [LogManager] ${dateString} ${tier} 大 payload (${originalSize} chars)，暫時提升等待上限至 ${Math.round(sendOptions.responseTimeoutMs / 1000)}s。`);
+            }
+            const rawResponse = await brain.sendMessage(prompt, false, sendOptions);
             const duration = ((Date.now() - startTime) / 1000).toFixed(1);
             const parsed = ResponseParser.parse(rawResponse);
             const summaryText = parsed.reply || "";
 
             if (!summaryText || summaryText.trim().length === 0) return;
 
-            // Optional: for daily, we could delete the raw messages afterwards. 
-            // the legacy json logic did it. We'll rely on cleanup() to delete old messages.
-
-            await this.runAsync(
-                `INSERT INTO summaries (tier, date_string, timestamp, content, original_size, summary_size) 
-                 VALUES (?, ?, ?, ?, ?, ?)`,
-                [tier, dateString, Date.now(), summaryText, originalSize, summaryText.length]
-            );
+            await this._insertSummary(tier, dateString, summaryText, originalSize);
 
             console.log(`✅ [LogManager] ${dateString} ${tier} 產出成功！(耗時: ${duration}s, 摘要: ${summaryText.length}字)`);
         } catch (e) {

--- a/src/services/MarketDecisionEngine.js
+++ b/src/services/MarketDecisionEngine.js
@@ -1,0 +1,182 @@
+function toNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function pickSelected(snapshot) {
+  if (snapshot && snapshot.selected && typeof snapshot.selected === 'object') return snapshot.selected;
+  if (snapshot && Array.isArray(snapshot.watchlist) && snapshot.watchlist.length) return snapshot.watchlist[0];
+  return null;
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function buildDecision(snapshot, options = {}) {
+  const mode = String(options.mode || 'stock').toLowerCase();
+  const selected = pickSelected(snapshot);
+  const indicators = snapshot && typeof snapshot.indicators === 'object' ? snapshot.indicators : {};
+  if (!selected) {
+    return {
+      verdict: 'hold',
+      confidence: 0.2,
+      score: 0,
+      reasons: ['No selected symbol in snapshot'],
+      riskFlags: ['insufficient_data'],
+      nextChecks: ['refresh_snapshot'],
+      plan: {
+        entry: null,
+        stopLossPct: null,
+        takeProfitPct: null,
+        positionSizePct: 0,
+      },
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  const rsi = toNumber(indicators.rsi14, NaN);
+  const macdHist = toNumber(indicators.macdHistogram, NaN);
+  const volumeRatio = toNumber(indicators.volumeRatio, NaN);
+  const distanceToSma = toNumber(indicators.distanceToSma20Percent, NaN);
+  const volatility = Math.abs(toNumber(indicators.volatility, 0));
+  const drawdown = Math.abs(toNumber(indicators.maxDrawdown, 0));
+
+  let score = 0;
+  const reasons = [];
+  const riskFlags = [];
+
+  if (Number.isFinite(rsi)) {
+    if (rsi <= 35) { score += 1.1; reasons.push(`RSI ${rsi.toFixed(1)} near oversold`); }
+    else if (rsi >= 70) { score -= 1.1; reasons.push(`RSI ${rsi.toFixed(1)} near overbought`); }
+  } else {
+    riskFlags.push('missing_rsi');
+  }
+
+  if (Number.isFinite(macdHist)) {
+    if (macdHist > 0) { score += 0.9; reasons.push('MACD histogram positive'); }
+    if (macdHist < 0) { score -= 0.9; reasons.push('MACD histogram negative'); }
+  } else {
+    riskFlags.push('missing_macd');
+  }
+
+  if (Number.isFinite(volumeRatio)) {
+    if (volumeRatio >= 1.25) { score += 0.5; reasons.push(`Volume ratio ${volumeRatio.toFixed(2)} supports move`); }
+    if (volumeRatio <= 0.7) { score -= 0.3; reasons.push(`Volume ratio ${volumeRatio.toFixed(2)} weak participation`); }
+  }
+
+  if (Number.isFinite(distanceToSma)) {
+    if (distanceToSma >= 5) { score += 0.3; reasons.push('Price above SMA20 trend zone'); }
+    if (distanceToSma <= -5) { score -= 0.3; reasons.push('Price below SMA20 trend zone'); }
+  }
+
+  if (volatility >= (mode === 'crypto' ? 90 : 45)) {
+    score -= 0.4;
+    riskFlags.push('high_volatility');
+  }
+  if (drawdown >= 18) {
+    score -= 0.4;
+    riskFlags.push('deep_drawdown');
+  }
+
+  const changePercent = toNumber(selected.changePercent, 0);
+  if (Math.abs(changePercent) >= (mode === 'crypto' ? 8 : 4)) {
+    riskFlags.push('intraday_extended_move');
+  }
+
+  let verdict = 'hold';
+  if (score >= 1.2) verdict = 'accumulate';
+  else if (score <= -1.2) verdict = 'reduce';
+
+  const confidence = clamp(0.45 + Math.min(Math.abs(score), 3) * 0.14 - riskFlags.length * 0.04, 0.2, 0.9);
+  const stopLossPct = mode === 'crypto' ? 4.5 : 3.2;
+  const takeProfitPct = mode === 'crypto' ? 9 : 6;
+  const basePositionPct = mode === 'crypto' ? 12 : 18;
+  const riskPenalty = Math.min(8, riskFlags.length * 2);
+  const positionSizePct = verdict === 'hold' ? Math.max(2, basePositionPct - riskPenalty - 4) : Math.max(2, basePositionPct - riskPenalty);
+
+  return {
+    symbol: selected.yahooSymbol || selected.symbol,
+    verdict,
+    confidence,
+    score,
+    reasons: reasons.slice(0, 6),
+    riskFlags,
+    nextChecks: [
+      'validate_news_headlines',
+      'confirm_market_breadth',
+      'recheck_after_next_refresh',
+    ],
+    plan: {
+      entry: toNumber(selected.price, 0),
+      stopLossPct,
+      takeProfitPct,
+      positionSizePct,
+    },
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function simulatePortfolio(snapshot, payload = {}) {
+  const selected = pickSelected(snapshot);
+  if (!selected) throw new Error('No selected symbol in snapshot');
+
+  const entryPrice = Math.max(0.000001, toNumber(payload.entryPrice, selected.price || 0));
+  const capital = Math.max(1, toNumber(payload.capital, 100000));
+  const positionSizePct = clamp(toNumber(payload.positionSizePct, 15), 1, 100);
+  const stopLossPct = clamp(Math.abs(toNumber(payload.stopLossPct, 3.5)), 0.1, 80);
+  const takeProfitPct = clamp(Math.abs(toNumber(payload.takeProfitPct, 7)), 0.1, 300);
+  const scenarioMoves = Array.isArray(payload.scenarioMoves) && payload.scenarioMoves.length
+    ? payload.scenarioMoves.map((v) => toNumber(v, 0)).filter((v) => Number.isFinite(v))
+    : [-10, -5, -2, 0, 2, 5, 10];
+
+  const positionCapital = capital * (positionSizePct / 100);
+  const quantity = positionCapital / entryPrice;
+  const stopPrice = entryPrice * (1 - stopLossPct / 100);
+  const takePrice = entryPrice * (1 + takeProfitPct / 100);
+
+  const scenarios = scenarioMoves.map((movePct) => {
+    const futurePrice = entryPrice * (1 + movePct / 100);
+    const pnl = (futurePrice - entryPrice) * quantity;
+    const pnlPctOnCapital = (pnl / capital) * 100;
+    return {
+      movePct,
+      futurePrice,
+      pnl,
+      pnlPctOnCapital,
+    };
+  });
+
+  const worst = scenarios.reduce((a, b) => (a.pnl < b.pnl ? a : b), scenarios[0]);
+  const best = scenarios.reduce((a, b) => (a.pnl > b.pnl ? a : b), scenarios[0]);
+
+  return {
+    symbol: selected.yahooSymbol || selected.symbol,
+    currency: selected.currency || 'USD',
+    assumptions: {
+      capital,
+      entryPrice,
+      positionSizePct,
+      stopLossPct,
+      takeProfitPct,
+      positionCapital,
+      quantity,
+      stopPrice,
+      takePrice,
+    },
+    scenarios,
+    summary: {
+      worstCasePnl: worst.pnl,
+      bestCasePnl: best.pnl,
+      maxRiskByStop: (stopPrice - entryPrice) * quantity,
+      expectedRewardByTarget: (takePrice - entryPrice) * quantity,
+      rrRatio: takeProfitPct / Math.max(0.01, stopLossPct),
+    },
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+module.exports = {
+  buildDecision,
+  simulatePortfolio,
+};

--- a/web-dashboard/routes/api.crypto.js
+++ b/web-dashboard/routes/api.crypto.js
@@ -20,10 +20,15 @@ const {
     consumeAiQuota,
     getAiQuotaStatus,
 } = require('../../src/services/CryptoMembershipService');
+const {
+    buildDecision,
+    simulatePortfolio,
+} = require('../../src/services/MarketDecisionEngine');
 
 const CACHE_TTL_MS = 45 * 1000;
 const SEARCH_CACHE_TTL_MS = 10 * 60 * 1000;
 const MAX_SYMBOLS = 20;
+const MOST_ACTIVE_LIMIT_MAX = 50;
 
 const cache = new Map();
 
@@ -746,6 +751,43 @@ async function fetchQuote(symbol) {
     return quote;
 }
 
+async function fetchCryptoMostActive(limit = 50) {
+    const safeLimit = clamp(toNumber(limit, 50), 1, MOST_ACTIVE_LIMIT_MAX);
+    const cacheKey = `most-active:crypto:${safeLimit}`;
+    const cached = getCached(cacheKey);
+    if (cached) return cached;
+
+    const url = `https://query1.finance.yahoo.com/v1/finance/screener/predefined/saved?count=${safeLimit}&scrIds=all_cryptocurrencies_us`;
+    const payload = await fetchJson(url);
+    const quotes = asArray(payload?.finance?.result?.[0]?.quotes);
+    const normalized = quotes.map((quote) => {
+        const yahooSymbol = String(quote?.symbol || '').toUpperCase();
+        const safeSymbol = normalizeSymbol(yahooSymbol);
+        const { base, quote: quoteCurrency } = splitPair(safeSymbol);
+        const price = toNullableNumber(quote?.regularMarketPrice);
+        const previousClose = toNullableNumber(quote?.regularMarketPreviousClose);
+        const change = toNullableNumber(quote?.regularMarketChange);
+        const changePercent = toNullableNumber(quote?.regularMarketChangePercent);
+        const volume = toNumber(quote?.regularMarketVolume, 0);
+        return {
+            symbol: base || getDisplaySymbol(safeSymbol),
+            yahooSymbol: safeSymbol,
+            name: String(quote?.shortName || quote?.longName || base || safeSymbol),
+            volume,
+            price,
+            change,
+            changePercent,
+            previousClose,
+            market: 'crypto',
+            currency: String(quoteCurrency || quote?.currency || 'USDT').toUpperCase(),
+            source: 'Yahoo Finance Screener',
+        };
+    }).filter((item) => item.yahooSymbol && item.volume > 0);
+
+    const sorted = normalized.sort((a, b) => b.volume - a.volume).slice(0, safeLimit);
+    return setCached(cacheKey, sorted, CACHE_TTL_MS);
+}
+
 async function searchYahoo(query) {
     const safeQuery = String(query || '').trim();
     if (!safeQuery) return [];
@@ -1133,6 +1175,23 @@ module.exports = function registerCryptoRoutes() {
         }
     });
 
+    router.get('/api/crypto/most-active', attachMembership, async (req, res) => {
+        try {
+            const limit = clamp(toNumber(req.query.limit, 50), 1, MOST_ACTIVE_LIMIT_MAX);
+            const items = await fetchCryptoMostActive(limit);
+            return res.json({
+                success: true,
+                market: 'crypto',
+                items,
+                generatedAt: new Date().toISOString(),
+                membership: req.cryptoMembership,
+            });
+        } catch (error) {
+            console.error('[Crypto] Failed to fetch most active list:', error);
+            return res.status(error.statusCode || 500).json({ error: error.message });
+        }
+    });
+
     router.get('/api/crypto/snapshot', attachMembership, (req, res) => {
         try {
             return res.json({
@@ -1202,6 +1261,34 @@ module.exports = function registerCryptoRoutes() {
             nonce: crypto.randomUUID(),
             generatedAt: new Date().toISOString(),
         });
+    });
+
+    router.post('/api/crypto/decision', attachMembership, (req, res) => {
+        try {
+            const snapshot = req.body?.snapshot || readCryptoSnapshot();
+            const decision = buildDecision(snapshot, { mode: 'crypto' });
+            return res.json({
+                success: true,
+                decision,
+                membership: req.cryptoMembership,
+            });
+        } catch (error) {
+            return res.status(400).json({ error: error.message });
+        }
+    });
+
+    router.post('/api/crypto/simulate', attachMembership, (req, res) => {
+        try {
+            const snapshot = req.body?.snapshot || readCryptoSnapshot();
+            const simulation = simulatePortfolio(snapshot, req.body || {});
+            return res.json({
+                success: true,
+                simulation,
+                membership: req.cryptoMembership,
+            });
+        } catch (error) {
+            return res.status(400).json({ error: error.message });
+        }
     });
 
     return router;

--- a/web-dashboard/routes/api.stocks.js
+++ b/web-dashboard/routes/api.stocks.js
@@ -11,10 +11,15 @@ const {
     searchStockSymbols,
     getDirectory,
 } = require('../../src/services/StockSymbolDirectory');
+const {
+    buildDecision,
+    simulatePortfolio,
+} = require('../../src/services/MarketDecisionEngine');
 
 const CACHE_TTL_MS = 45 * 1000;
 const SEARCH_CACHE_TTL_MS = 10 * 60 * 1000;
 const MAX_SYMBOLS = 20;
+const MOST_ACTIVE_LIMIT_MAX = 50;
 
 const cache = new Map();
 
@@ -34,6 +39,13 @@ const TW_FALLBACK_NAMES = {
 };
 const TAIWAN_SYMBOL_RE = /^\d{4,6}[A-Z]{0,3}$/;
 const TAIWAN_YAHOO_SYMBOL_RE = /^\d{4,6}[A-Z]{0,3}\.(TW|TWO)$/;
+const SYMBOL_ALIASES = {
+    TPEX: '^TWOII',
+    TPEx: '^TWOII',
+    OTC: '^TWOII',
+    TAIEX: '^TWII',
+    TWSE: '^TWII',
+};
 
 function createHttpError(statusCode, message) {
     const error = new Error(message);
@@ -101,14 +113,39 @@ function toPositiveNullableNumber(value) {
     return numericValue && numericValue > 0 ? numericValue : null;
 }
 
+function readYahooRawValue(value) {
+    if (value && typeof value === 'object' && value.raw !== undefined) {
+        return value.raw;
+    }
+    return value;
+}
+
 function clamp(value, min, max) {
     return Math.max(min, Math.min(max, value));
+}
+
+function pickFirst(row, keys) {
+    for (const key of keys) {
+        if (row && row[key] !== undefined && row[key] !== null && row[key] !== '') {
+            return row[key];
+        }
+    }
+    return null;
+}
+
+function toLooseNumber(value) {
+    if (value === null || value === undefined) return null;
+    const cleaned = String(value).replace(/,/g, '').trim();
+    if (!cleaned || cleaned === '--' || cleaned === '---') return null;
+    const numeric = Number(cleaned);
+    return Number.isFinite(numeric) ? numeric : null;
 }
 
 function normalizeSymbol(input) {
     const raw = String(input || '').trim().toUpperCase();
     if (!raw) return '';
     const cleaned = raw.replace(/\s+/g, '');
+    if (SYMBOL_ALIASES[cleaned]) return SYMBOL_ALIASES[cleaned];
     if (TAIWAN_SYMBOL_RE.test(cleaned)) return `${cleaned}.TW`;
     if (TAIWAN_YAHOO_SYMBOL_RE.test(cleaned)) return cleaned;
     return cleaned.replace(/[^A-Z0-9.^=-]/g, '').slice(0, 24);
@@ -397,9 +434,126 @@ async function fetchChart(symbol, range = '1d', interval = '5m') {
     }
 }
 
+async function fetchQuoteSummary(symbol) {
+    const safeSymbol = normalizeSymbol(symbol);
+    if (!safeSymbol) return {};
+    const cacheKey = `summary:${safeSymbol}`;
+    const cached = getCached(cacheKey);
+    if (cached) return cached;
+
+    const modules = [
+        'summaryDetail',
+        'defaultKeyStatistics',
+        'financialData',
+    ].join(',');
+    const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(safeSymbol)}?modules=${encodeURIComponent(modules)}`;
+    try {
+        const payload = await fetchJson(url);
+        const result = payload?.quoteSummary?.result?.[0] || {};
+        const summaryDetail = result.summaryDetail || {};
+        const statistics = result.defaultKeyStatistics || {};
+        const financialData = result.financialData || {};
+
+        const summary = {
+            trailingPE: toPositiveNullableNumber(readYahooRawValue(summaryDetail.trailingPE)),
+            forwardPE: toPositiveNullableNumber(readYahooRawValue(summaryDetail.forwardPE)),
+            priceToBook: toPositiveNullableNumber(readYahooRawValue(summaryDetail.priceToBook)),
+            beta: toNullableNumber(readYahooRawValue(summaryDetail.beta)),
+            dividendYield: toPositiveNullableNumber(readYahooRawValue(summaryDetail.dividendYield)),
+            dividendRate: toPositiveNullableNumber(readYahooRawValue(summaryDetail.dividendRate)),
+            payoutRatio: toPositiveNullableNumber(readYahooRawValue(summaryDetail.payoutRatio)),
+            epsTrailingTwelveMonths: toNullableNumber(readYahooRawValue(financialData.epsTrailingTwelveMonths)),
+            epsForward: toNullableNumber(readYahooRawValue(financialData.epsForward)),
+            recommendationKey: summaryDetail.recommendationKey || financialData.recommendationKey || null,
+            targetMeanPrice: toPositiveNullableNumber(readYahooRawValue(financialData.targetMeanPrice)),
+            numberOfAnalystOpinions: toPositiveNullableNumber(readYahooRawValue(financialData.numberOfAnalystOpinions)),
+            sharesOutstanding: toPositiveNullableNumber(readYahooRawValue(statistics.sharesOutstanding)),
+        };
+        return setCached(cacheKey, summary, CACHE_TTL_MS);
+    } catch (_error) {
+        return {};
+    }
+}
+
 async function fetchQuote(symbol) {
     const result = await fetchChart(symbol, '1d', '5m');
-    return normalizeQuote(normalizeSymbol(symbol), result);
+    const summary = await fetchQuoteSummary(symbol);
+    return { ...normalizeQuote(normalizeSymbol(symbol), result), ...summary };
+}
+
+async function fetchTwseMostActive(limit = 50) {
+    const safeLimit = clamp(toNumber(limit, 50), 1, MOST_ACTIVE_LIMIT_MAX);
+    const cacheKey = `most-active:tw:${safeLimit}`;
+    const cached = getCached(cacheKey);
+    if (cached) return cached;
+
+    const payload = await fetchJson('https://openapi.twse.com.tw/v1/exchangeReport/STOCK_DAY_ALL');
+    const rows = Array.isArray(payload) ? payload : [];
+    const normalized = rows.map((row) => {
+        const symbol = String(pickFirst(row, ['Code', '證券代號']) || '').trim();
+        const name = String(pickFirst(row, ['Name', '證券名稱']) || symbol).trim();
+        const volume = toLooseNumber(pickFirst(row, ['TradeVolume', '成交股數'])) || 0;
+        const close = toLooseNumber(pickFirst(row, ['ClosingPrice', '收盤價']));
+        const change = toLooseNumber(pickFirst(row, ['Change', '漲跌價差']));
+        const previousClose = close !== null && change !== null ? close - change : null;
+        const changePercent = close !== null && previousClose && previousClose !== 0
+            ? ((close - previousClose) / previousClose) * 100
+            : null;
+        return {
+            symbol,
+            yahooSymbol: symbol ? normalizeSymbol(symbol) : '',
+            name,
+            volume,
+            price: close,
+            change,
+            changePercent,
+            previousClose,
+            market: 'tw',
+            currency: 'TWD',
+            source: 'TWSE OpenAPI + Yahoo symbol normalize',
+        };
+    }).filter((item) => item.symbol && item.volume > 0);
+
+    const top = normalized
+        .sort((a, b) => b.volume - a.volume)
+        .slice(0, safeLimit);
+    return setCached(cacheKey, top, CACHE_TTL_MS);
+}
+
+async function fetchUsMostActive(limit = 50) {
+    const safeLimit = clamp(toNumber(limit, 50), 1, MOST_ACTIVE_LIMIT_MAX);
+    const cacheKey = `most-active:us:${safeLimit}`;
+    const cached = getCached(cacheKey);
+    if (cached) return cached;
+
+    const url = `https://query1.finance.yahoo.com/v1/finance/screener/predefined/saved?count=${safeLimit}&scrIds=most_actives`;
+    const payload = await fetchJson(url);
+    const quotes = asArray(payload?.finance?.result?.[0]?.quotes);
+    const normalized = quotes.map((quote) => {
+        const symbolRaw = String(quote?.symbol || '').trim().toUpperCase();
+        const symbol = getDisplaySymbol(symbolRaw);
+        const yahooSymbol = normalizeSymbol(symbolRaw);
+        const price = toNullableNumber(quote?.regularMarketPrice);
+        const previousClose = toNullableNumber(quote?.regularMarketPreviousClose);
+        const change = toNullableNumber(quote?.regularMarketChange);
+        const changePercent = toNullableNumber(quote?.regularMarketChangePercent);
+        const volume = toNumber(quote?.regularMarketVolume, 0);
+        return {
+            symbol,
+            yahooSymbol,
+            name: String(quote?.longName || quote?.shortName || symbol || yahooSymbol),
+            volume,
+            price,
+            change,
+            changePercent,
+            previousClose,
+            market: 'us',
+            currency: String(quote?.currency || 'USD'),
+            source: 'Yahoo Finance Screener',
+        };
+    }).filter((item) => item.yahooSymbol && item.volume > 0);
+
+    return setCached(cacheKey, normalized.slice(0, safeLimit), CACHE_TTL_MS);
 }
 
 async function searchYahoo(query) {
@@ -489,10 +643,13 @@ module.exports = function registerStockRoutes() {
     });
 
     router.get('/api/stocks/history', async (req, res) => {
+        let symbol = '';
+        let range = '3mo';
+        let interval = '1d';
         try {
-            const symbol = normalizeSymbol(req.query.symbol);
-            const range = String(req.query.range || '3mo');
-            const interval = String(req.query.interval || (range === '1d' ? '5m' : '1d'));
+            symbol = normalizeSymbol(req.query.symbol);
+            range = String(req.query.range || '3mo');
+            interval = String(req.query.interval || (range === '1d' ? '5m' : '1d'));
             const allowedRanges = new Set(['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y']);
             const allowedIntervals = new Set(['1m', '5m', '15m', '30m', '60m', '1d', '1wk']);
             if (!symbol) return res.status(400).json({ error: 'Missing symbol' });
@@ -508,7 +665,7 @@ module.exports = function registerStockRoutes() {
                 generatedAt: new Date().toISOString(),
             });
         } catch (error) {
-            console.error('[Stocks] Failed to fetch history:', error);
+            console.error(`[Stocks] Failed to fetch history (symbol=${symbol || 'N/A'}, range=${range}, interval=${interval}):`, error);
             return res.status(error.statusCode || 500).json({ error: error.message });
         }
     });
@@ -637,6 +794,51 @@ module.exports = function registerStockRoutes() {
         } catch (error) {
             console.error('[Stocks] Failed to refresh snapshot:', error);
             return res.status(error.statusCode || 500).json({ error: error.message });
+        }
+    });
+
+    router.get('/api/stocks/most-active', async (req, res) => {
+        try {
+            const market = String(req.query.market || 'tw').toLowerCase();
+            const limit = clamp(toNumber(req.query.limit, 50), 1, MOST_ACTIVE_LIMIT_MAX);
+            const items = market === 'us'
+                ? await fetchUsMostActive(limit)
+                : await fetchTwseMostActive(limit);
+            return res.json({
+                success: true,
+                market: market === 'us' ? 'us' : 'tw',
+                items,
+                generatedAt: new Date().toISOString(),
+            });
+        } catch (error) {
+            console.error('[Stocks] Failed to fetch most active list:', error);
+            return res.status(error.statusCode || 500).json({ error: error.message });
+        }
+    });
+
+    router.post('/api/stocks/decision', (req, res) => {
+        try {
+            const snapshot = req.body?.snapshot || readStockSnapshot();
+            const decision = buildDecision(snapshot, { mode: 'stock' });
+            return res.json({
+                success: true,
+                decision,
+            });
+        } catch (error) {
+            return res.status(400).json({ error: error.message });
+        }
+    });
+
+    router.post('/api/stocks/simulate', (req, res) => {
+        try {
+            const snapshot = req.body?.snapshot || readStockSnapshot();
+            const simulation = simulatePortfolio(snapshot, req.body || {});
+            return res.json({
+                success: true,
+                simulation,
+            });
+        } catch (error) {
+            return res.status(400).json({ error: error.message });
         }
     });
 

--- a/web-dashboard/src/app/dashboard/crypto/page.tsx
+++ b/web-dashboard/src/app/dashboard/crypto/page.tsx
@@ -206,6 +206,25 @@ type SnapshotRefreshResponse = {
         remaining: number;
     };
 };
+type MostActiveItem = {
+    symbol: string;
+    yahooSymbol: string;
+    name: string;
+    volume: number;
+    price: number | null;
+    change: number | null;
+    changePercent: number | null;
+    previousClose: number | null;
+    market: "crypto";
+    currency: string;
+    source: string;
+};
+type MostActiveResponse = {
+    success?: boolean;
+    market?: "crypto";
+    items?: MostActiveItem[];
+    generatedAt?: string;
+};
 
 type CryptoEntitlements = {
     tier: "visitor" | "general" | "sponsor";
@@ -241,6 +260,8 @@ type AccessGateState = {
 };
 type PositioningPeriod = "5m" | "15m" | "1h" | "1d";
 type PositioningViewMode = "ratio" | "inference";
+type CryptoAnalysisMethodKey = "balanced" | "trend_following" | "mean_reversion" | "risk_control";
+type AnalysisScope = "selected" | "watchlist";
 
 type CryptoDashboardSnapshot = {
     source: string;
@@ -372,6 +393,52 @@ const RANGE_MAP: Record<RangeKey, { range: string; interval: string; label: stri
     "1d": { range: "1y", interval: "1d", label: "1D" },
     "1M": { range: "2y", interval: "1mo", label: "1M" },
 };
+const CRYPTO_ANALYSIS_METHODS: Array<{
+    key: CryptoAnalysisMethodKey;
+    labelZh: string;
+    labelEn: string;
+    explainZh: string;
+    explainEn: string;
+    promptZh: string;
+    promptEn: string;
+}> = [
+    {
+        key: "balanced",
+        labelZh: "平衡評估",
+        labelEn: "Balanced",
+        explainZh: "綜合趨勢、動能、量價與市場情緒，提供中性且可執行的判斷。",
+        explainEn: "Combines trend, momentum, volume, and sentiment into a practical balanced plan.",
+        promptZh: "請做平衡型加密市場分析：先趨勢、再動能與量價，最後給偏多/中性/偏空情境與對應策略。",
+        promptEn: "Run balanced crypto analysis: trend first, then momentum/volume, then bullish/neutral/bearish scenarios with strategy.",
+    },
+    {
+        key: "trend_following",
+        labelZh: "趨勢追蹤",
+        labelEn: "Trend Following",
+        explainZh: "以順勢交易為主，重視突破、回踩與趨勢延續。",
+        explainEn: "Prioritizes continuation setups with breakouts, retests, and trend persistence.",
+        promptZh: "請以趨勢追蹤角度分析：給出關鍵突破位、失效位，並提出順勢入場與風控條件。",
+        promptEn: "Analyze with trend-following logic: breakout/invalidation levels, continuation entry, and risk controls.",
+    },
+    {
+        key: "mean_reversion",
+        labelZh: "均值回歸",
+        labelEn: "Mean Reversion",
+        explainZh: "以超漲超跌修正為核心，重視 RSI、布林通道與量能衰竭。",
+        explainEn: "Focuses on overextension pullbacks using RSI, Bollinger context, and volume exhaustion.",
+        promptZh: "請以均值回歸角度分析：判斷是否超漲/超跌，提出分批進出與失效條件。",
+        promptEn: "Analyze for mean reversion: detect overbought/oversold conditions and propose scaled entry/exit with invalidation.",
+    },
+    {
+        key: "risk_control",
+        labelZh: "風險控管",
+        labelEn: "Risk Control",
+        explainZh: "以保本與回撤控制優先，強調倉位、停損與波動管理。",
+        explainEn: "Capital protection first, emphasizing sizing, stop-loss, and volatility control.",
+        promptZh: "請以風險控管為主：建議倉位%、停損區間、停利區間，並說明不交易條件。",
+        promptEn: "Prioritize risk control: recommend position size %, stop/target zones, and explicit no-trade conditions.",
+    },
+];
 const HISTORY_RANGE_ORDER = ["1d", "2d", "5d", "1mo", "3mo", "6mo", "1y", "2y"] as const;
 const CHART_WINDOW_SIZE: Record<RangeKey, number> = {
     "5m": 90,
@@ -556,6 +623,16 @@ function getFreshnessLabel(value: string, localeCode: string) {
         hour: "2-digit",
         minute: "2-digit",
     }).format(new Date(parsed));
+}
+
+function getCryptoMethodLabel(method: CryptoAnalysisMethodKey, isEnglish: boolean) {
+    const found = CRYPTO_ANALYSIS_METHODS.find((item) => item.key === method) || CRYPTO_ANALYSIS_METHODS[0];
+    return isEnglish ? found.labelEn : found.labelZh;
+}
+
+function buildCryptoPromptTemplate(method: CryptoAnalysisMethodKey, isEnglish: boolean) {
+    const found = CRYPTO_ANALYSIS_METHODS.find((item) => item.key === method) || CRYPTO_ANALYSIS_METHODS[0];
+    return isEnglish ? found.promptEn : found.promptZh;
 }
 
 function resolveHistoryConfigForTier(
@@ -819,9 +896,13 @@ export default function CryptoAnalysisPage() {
     const [isLoadingQuotes, setIsLoadingQuotes] = useState(true);
     const [isLoadingHistory, setIsLoadingHistory] = useState(false);
     const [isLoadingNews, setIsLoadingNews] = useState(false);
+    const [isLoadingMostActive, setIsLoadingMostActive] = useState(false);
     const [isSearching, setIsSearching] = useState(false);
     const [isSending, setIsSending] = useState(false);
     const [sentSnapshot, setSentSnapshot] = useState(false);
+    const [analysisMethod, setAnalysisMethod] = useState<CryptoAnalysisMethodKey>("balanced");
+    const [analysisScope, setAnalysisScope] = useState<AnalysisScope>("selected");
+    const [analysisPrompt, setAnalysisPrompt] = useState("");
     const [lastUpdatedAt, setLastUpdatedAt] = useState("");
     const [showSupportPrompt, setShowSupportPrompt] = useState(false);
     const [supportCopyIndex, setSupportCopyIndex] = useState(0);
@@ -842,6 +923,9 @@ export default function CryptoAnalysisPage() {
     const [positioningViewMode, setPositioningViewMode] = useState<PositioningViewMode>("ratio");
     const [positioningData, setPositioningData] = useState<PositioningResponse["positioning"] | null>(null);
     const [isLoadingPositioning, setIsLoadingPositioning] = useState(false);
+    const [mostActiveItems, setMostActiveItems] = useState<MostActiveItem[]>([]);
+    const [showAllMostActive, setShowAllMostActive] = useState(false);
+    const [mostActiveActions, setMostActiveActions] = useState<Record<string, "add" | "chart" | "ask" | "news">>({});
     const pendingRetryRef = useRef<null | (() => void)>(null);
     const lastInteractionRefreshRef = useRef(0);
     const newsCardRef = useRef<HTMLDivElement | null>(null);
@@ -1038,12 +1122,26 @@ export default function CryptoAnalysisPage() {
         }
     }, [handleApiAccessError, isEnglish, membership?.entitlements?.historyRangeLimit, quotePreference, toast]);
 
+    const loadMostActive = useCallback(async () => {
+        setIsLoadingMostActive(true);
+        try {
+            const data = await apiGet<MostActiveResponse>(apiUrl("/api/crypto/most-active?limit=50"));
+            setMostActiveItems(Array.isArray(data.items) ? data.items : []);
+        } catch (error) {
+            console.warn("[Crypto] Failed to load most active list:", error);
+            setMostActiveItems([]);
+        } finally {
+            setIsLoadingMostActive(false);
+        }
+    }, []);
+
     const refreshDashboard = useCallback(async () => {
         await Promise.all([
             loadQuotes(),
             loadHistory(selectedSymbol, range),
+            loadMostActive(),
         ]);
-    }, [loadHistory, loadQuotes, range, selectedSymbol]);
+    }, [loadHistory, loadMostActive, loadQuotes, range, selectedSymbol]);
 
     const loadNews = useCallback(async (quote: CryptoQuote | null) => {
         if (!quote?.yahooSymbol) {
@@ -1076,6 +1174,12 @@ export default function CryptoAnalysisPage() {
         // eslint-disable-next-line react-hooks/set-state-in-effect
         loadQuotes();
     }, [isRuntimeActive, loadQuotes]);
+
+    useEffect(() => {
+        if (!isRuntimeActive) return;
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        loadMostActive();
+    }, [isRuntimeActive, loadMostActive]);
 
     useEffect(() => {
         if (!isRuntimeActive) return;
@@ -1373,6 +1477,15 @@ export default function CryptoAnalysisPage() {
         generatedAt: new Date().toISOString(),
     }), [indicators, isSponsorTier, latestPositioning, marketBreadth, news, positioningChartData, positioningData?.pair, positioningData?.source, positioningPeriod, positioningSource, quoteErrors, range, selectedMarket, selectedQuote, visibleQuotes]);
 
+    const selectedAnalysisMethod = useMemo(
+        () => CRYPTO_ANALYSIS_METHODS.find((item) => item.key === analysisMethod) || CRYPTO_ANALYSIS_METHODS[0],
+        [analysisMethod]
+    );
+
+    useEffect(() => {
+        setAnalysisPrompt(buildCryptoPromptTemplate(analysisMethod, isEnglish));
+    }, [analysisMethod, isEnglish]);
+
     useEffect(() => {
         if (!isRuntimeActive) return;
         if (!selectedQuote || !quotes.length) return;
@@ -1405,7 +1518,7 @@ export default function CryptoAnalysisPage() {
         });
     };
 
-    const handleAskGolem = async () => {
+    const handleAskGolem = async (targetSymbol?: string) => {
         if (!activeGolem) {
             toast.warning(
                 isEnglish ? "No active Golem" : "沒有可用的 Golem",
@@ -1429,13 +1542,28 @@ export default function CryptoAnalysisPage() {
         setIsSending(true);
         setSentSnapshot(false);
         try {
-            await refreshDashboard();
+            const selectedForRequest = targetSymbol ? normalizeSymbol(targetSymbol, quotePreference) : selectedSymbol;
+            if (targetSymbol) {
+                setSelectedSymbol(selectedForRequest);
+                await Promise.all([
+                    loadQuotes(),
+                    loadHistory(selectedForRequest, range),
+                    loadMostActive(),
+                ]);
+            } else {
+                await refreshDashboard();
+            }
+            const analysisSymbols = targetSymbol
+                ? [selectedForRequest]
+                : analysisScope === "selected"
+                ? [selectedSymbol]
+                : watchlist;
             let snapshotForGolem = snapshot;
             try {
                 const refreshed = await apiPost<SnapshotRefreshResponse>(apiUrl("/api/crypto/snapshot/refresh"), {
                     snapshot,
-                    symbols: watchlist,
-                    selectedSymbol,
+                    symbols: analysisSymbols,
+                    selectedSymbol: selectedForRequest,
                     selectedRange: range,
                     marketFilter: selectedMarket,
                     trigger: "dashboard-before-golem-analysis",
@@ -1458,12 +1586,24 @@ export default function CryptoAnalysisPage() {
                 );
                 return;
             }
-            const symbolsForPrompt = Array.from(new Set([selectedSymbol, ...watchlist].map((symbol) => normalizeSymbol(symbol, quotePreference)).filter(Boolean)));
+            const symbolsForPrompt = Array.from(new Set(analysisSymbols.map((symbol) => normalizeSymbol(symbol, quotePreference)).filter(Boolean)));
+            const userPrompt = String(analysisPrompt || "").trim() || buildCryptoPromptTemplate(analysisMethod, isEnglish);
             const message = [
                 `/cryptoboard ${symbolsForPrompt.join(" ")}`,
                 isEnglish
-                    ? "Analyze the current Dashboard crypto snapshot. The dashboard has synchronized the latest server-side structured snapshot; use that as the primary source, mention freshness, and avoid guaranteed financial advice."
-                    : "請分析目前 Dashboard 加密貨幣看板。Dashboard 已先同步最新的 server-side 結構化快照；請以完整快照為主要資料來源，說明資料新鮮度，且不要做保證式投資建議。",
+                    ? `Analysis method: ${getCryptoMethodLabel(analysisMethod, true)}`
+                    : `分析方法：${getCryptoMethodLabel(analysisMethod, false)}`,
+                isEnglish
+                    ? `Analysis scope: ${analysisScope === "selected" ? "selected symbol only" : "entire watchlist"}`
+                    : `分析範圍：${analysisScope === "selected" ? "僅目前標的" : "全部自選"}`,
+                targetSymbol
+                    ? (isEnglish ? "Forced scope: single symbol action from Top Volume list." : "強制範圍：由成交量榜單觸發之單一標的分析。")
+                    : "",
+                isEnglish ? "User strategy prompt:" : "使用者策略提示：",
+                userPrompt,
+                isEnglish
+                    ? "Use the latest Dashboard structured snapshot as primary evidence. Explicitly mention data freshness and uncertainty; avoid guaranteed financial advice."
+                    : "請以最新 Dashboard 結構化快照為主要依據，明確標示資料新鮮度與不確定性，避免保證式投資建議。",
                 snapshotForGolem?.generatedAt
                     ? `${isEnglish ? "Snapshot generated at" : "快照產生時間"}: ${snapshotForGolem.generatedAt}`
                     : "",
@@ -1472,7 +1612,7 @@ export default function CryptoAnalysisPage() {
             setSentSnapshot(true);
             toast.success(
                 isEnglish ? "Snapshot sent" : "已送出看板快照",
-                isEnglish ? "Golem is analyzing the live board in the console." : "Golem 會在控制台裡分析這份即時看板。"
+                isEnglish ? "Please open Chat to view the analysis result." : "請直接到交談功能查看分析結果。"
             );
             loadMembership();
         } catch (error) {
@@ -1486,6 +1626,47 @@ export default function CryptoAnalysisPage() {
         } finally {
             setIsSending(false);
         }
+    };
+
+    const handleMostActiveAction = async (item: MostActiveItem) => {
+        const action = mostActiveActions[item.yahooSymbol] || "add";
+        if (action === "add") {
+            addSymbol(item.yahooSymbol);
+            return;
+        }
+        if (action === "chart") {
+            setSelectedSymbol(item.yahooSymbol);
+            await loadHistory(item.yahooSymbol, range);
+            return;
+        }
+        if (action === "news") {
+            await loadNews({
+                symbol: item.symbol,
+                yahooSymbol: item.yahooSymbol,
+                name: item.name,
+                market: "crypto",
+                currency: item.currency || "USDT",
+                exchangeName: "",
+                exchangeTimezoneName: "UTC",
+                price: Number(item.price || 0),
+                previousClose: Number(item.previousClose || 0),
+                open: null,
+                dayHigh: null,
+                dayLow: null,
+                fiftyTwoWeekHigh: null,
+                fiftyTwoWeekLow: null,
+                change: Number(item.change || 0),
+                changePercent: Number(item.changePercent || 0),
+                volume: Number(item.volume || 0),
+                turnover: Number(item.volume || 0) * Number(item.price || 0),
+                marketCap: null,
+                sector: "Crypto",
+                dataSource: item.source || "Most Active",
+                lastUpdatedAt: new Date().toISOString(),
+            });
+            return;
+        }
+        await handleAskGolem(item.yahooSymbol);
     };
 
     const handleMembershipLogin = async () => {
@@ -1801,7 +1982,7 @@ export default function CryptoAnalysisPage() {
                             <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
                             <div className="space-y-1 text-xs leading-5 text-muted-foreground">
                                 <div className="font-semibold text-foreground">{isEnglish ? "How to use" : "使用說明"}</div>
-                                <p>{isEnglish ? `Search a symbol, select a watchlist row, then ask Golem. Quote preference is ${quotePreference}; current tier refreshes every ${Math.round(refreshIntervalMs / 1000)} seconds.` : `搜尋加密貨幣、點選自選股列，再請 Golem 分析。交易對偏好為 ${quotePreference}，目前會員層級每 ${Math.round(refreshIntervalMs / 1000)} 秒刷新。`}</p>
+                                <p>{isEnglish ? `Search a symbol, choose an analysis method, edit prompt if needed, then ask Golem. Quote preference is ${quotePreference}; current tier refreshes every ${Math.round(refreshIntervalMs / 1000)} seconds.` : `搜尋加密貨幣、選擇分析方法、必要時調整 prompt，再請 Golem 分析。交易對偏好為 ${quotePreference}，目前會員層級每 ${Math.round(refreshIntervalMs / 1000)} 秒刷新。`}</p>
                                 <p>{isEnglish ? "This board is not a second-level feed. For sub-second/second-level execution, use professional exchange trading software." : "本看板非秒級行情來源；若需秒級或亞秒級執行，請改用專業交易所交易軟體。"}</p>
                                 <p>{isEnglish ? "Sponsor refresh is capped at 15 seconds to avoid upstream IP blocking." : "為避免資料源封鎖 IP，Sponsor 更新上限固定為每 15 秒一次。"}</p>
                             </div>
@@ -1874,7 +2055,7 @@ export default function CryptoAnalysisPage() {
                                 </div>
                             )}
 
-                            <div className="max-h-[320px] min-h-[146px] overflow-y-auto rounded-lg border border-border bg-secondary/25">
+                            <div className="max-h-[260px] min-h-[120px] overflow-y-auto rounded-lg border border-border bg-secondary/25">
                                 {isSearching ? (
                                     <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
                                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -1902,6 +2083,33 @@ export default function CryptoAnalysisPage() {
                                         {isEnglish ? `Search by symbol or coin name. Inputs like BTC/ETH auto-normalize to -${quotePreference}.` : `可搜尋代號或幣種名稱。像 BTC/ETH 會自動正規化成 -${quotePreference}。`}
                                     </div>
                                 )}
+                            </div>
+                            <div className="space-y-2">
+                                <div className="text-xs text-muted-foreground">
+                                    {isEnglish ? "Quick switch watchlist" : "快速切換自選"}
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                    {visibleQuotes.slice(0, 6).map((quote) => (
+                                        <button
+                                            key={`quick-${quote.yahooSymbol}`}
+                                            type="button"
+                                            onClick={() => setSelectedSymbol(quote.yahooSymbol)}
+                                            className={cn(
+                                                "rounded-md border px-2.5 py-1 text-xs transition-colors",
+                                                selectedSymbol === quote.yahooSymbol
+                                                    ? "border-primary bg-primary/10 text-primary"
+                                                    : "border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground"
+                                            )}
+                                        >
+                                            {quote.symbol}
+                                        </button>
+                                    ))}
+                                    {!visibleQuotes.length && (
+                                        <span className="text-xs text-muted-foreground">
+                                            {isEnglish ? "No watchlist symbols yet." : "尚未有自選標的。"}
+                                        </span>
+                                    )}
+                                </div>
                             </div>
                         </CardContent>
                     </Card>
@@ -1932,30 +2140,127 @@ export default function CryptoAnalysisPage() {
                                         ? `${selectedQuote.dataSource}${selectedQuote.dataQuality === "stale-cache" ? (isEnglish ? " · stale cache" : " · 快取資料") : ""} · ${getFreshnessLabel(selectedQuote.lastUpdatedAt, localeCode)}`
                                         : isEnglish ? "No quote selected." : "尚未選取行情。"}
                                 </p>
+                                <div className="grid grid-cols-2 gap-2 text-xs">
+                                    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+                                        <div className="text-muted-foreground">{isEnglish ? "24h High" : "24h 高點"}</div>
+                                        <div className="mt-0.5 font-semibold">{formatNumber(selectedQuote?.dayHigh, localeCode)}</div>
+                                    </div>
+                                    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+                                        <div className="text-muted-foreground">{isEnglish ? "24h Low" : "24h 低點"}</div>
+                                        <div className="mt-0.5 font-semibold">{formatNumber(selectedQuote?.dayLow, localeCode)}</div>
+                                    </div>
+                                    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+                                        <div className="text-muted-foreground">{isEnglish ? "Volume" : "成交量"}</div>
+                                        <div className="mt-0.5 font-semibold">{formatCompact(selectedQuote?.volume, localeCode)}</div>
+                                    </div>
+                                    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+                                        <div className="text-muted-foreground">{isEnglish ? "Turnover" : "成交值"}</div>
+                                        <div className="mt-0.5 font-semibold">{formatCompact(selectedQuote?.turnover, localeCode)}</div>
+                                    </div>
+                                </div>
+                                <div className="rounded-lg border border-border/70 bg-secondary/30 p-2.5">
+                                    <div className="mb-2 text-xs text-muted-foreground">{isEnglish ? "Market Breadth" : "市場廣度"}</div>
+                                    <div className="grid grid-cols-3 gap-2">
+                                        <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-2 py-1.5">
+                                            <div className="text-[11px] text-muted-foreground">{isEnglish ? "Up" : "上漲"}</div>
+                                            <div className="text-base font-semibold text-emerald-600 dark:text-emerald-400">{marketBreadth.advancers}</div>
+                                        </div>
+                                        <div className="rounded-md border border-rose-500/20 bg-rose-500/10 px-2 py-1.5">
+                                            <div className="text-[11px] text-muted-foreground">{isEnglish ? "Down" : "下跌"}</div>
+                                            <div className="text-base font-semibold text-rose-600 dark:text-rose-400">{marketBreadth.decliners}</div>
+                                        </div>
+                                        <div className="rounded-md border border-sky-500/20 bg-sky-500/10 px-2 py-1.5">
+                                            <div className="text-[11px] text-muted-foreground">{isEnglish ? "Avg" : "平均"}</div>
+                                            <div className={cn("text-base font-semibold", getQuoteTone(marketBreadth.averageMove))}>
+                                                {marketBreadth.averageMove >= 0 ? "+" : ""}
+                                                {formatNumber(marketBreadth.averageMove, localeCode)}%
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </CardContent>
                         </Card>
 
                         <Card className="rounded-lg border-border/80">
                             <CardHeader className="pb-3">
-                                <CardDescription>{isEnglish ? "Market Breadth" : "市場廣度"}</CardDescription>
-                                <CardTitle className="text-xl">{isEnglish ? "Watchlist Pulse" : "自選股脈動"}</CardTitle>
+                                <CardDescription>{isEnglish ? "Volume Leaderboard" : "成交量排行榜"}</CardDescription>
+                                <CardTitle className="text-xl">{isEnglish ? "Crypto Top 50 by Volume" : "加密成交量 Top 50"}</CardTitle>
                             </CardHeader>
-                            <CardContent className="grid grid-cols-3 gap-3">
-                                <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
-                                    <div className="text-xs text-muted-foreground">{isEnglish ? "Up" : "上漲"}</div>
-                                    <div className="mt-1 text-2xl font-semibold text-emerald-600 dark:text-emerald-400">{marketBreadth.advancers}</div>
-                                </div>
-                                <div className="rounded-lg border border-rose-500/20 bg-rose-500/10 p-3">
-                                    <div className="text-xs text-muted-foreground">{isEnglish ? "Down" : "下跌"}</div>
-                                    <div className="mt-1 text-2xl font-semibold text-rose-600 dark:text-rose-400">{marketBreadth.decliners}</div>
-                                </div>
-                                <div className="rounded-lg border border-sky-500/20 bg-sky-500/10 p-3">
-                                    <div className="text-xs text-muted-foreground">{isEnglish ? "Avg" : "平均"}</div>
-                                    <div className={cn("mt-1 text-2xl font-semibold", getQuoteTone(marketBreadth.averageMove))}>
-                                        {marketBreadth.averageMove >= 0 ? "+" : ""}
-                                        {formatNumber(marketBreadth.averageMove, localeCode)}%
+                            <CardContent className="space-y-3">
+                                {isLoadingMostActive ? (
+                                    <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                        {isEnglish ? "Loading active symbols..." : "讀取熱門成交標的中..."}
                                     </div>
-                                </div>
+                                ) : mostActiveItems.length ? (
+                                    <div className="max-h-[310px] overflow-y-auto rounded-lg border border-border bg-background/40">
+                                        <div className="divide-y divide-border/70">
+                                            {mostActiveItems.slice(0, showAllMostActive ? 50 : 20).map((item) => (
+                                                <div key={`crypto-active-${item.yahooSymbol}`} className="space-y-2 px-3 py-2.5">
+                                                    <div className="flex items-start justify-between gap-2">
+                                                        <div className="min-w-0">
+                                                            <div className="truncate text-sm font-semibold">{item.symbol} · {item.name}</div>
+                                                            <div className="text-xs text-muted-foreground">
+                                                                {isEnglish ? "Volume" : "成交量"} {formatCompact(item.volume, localeCode)}
+                                                            </div>
+                                                        </div>
+                                                        <div className="text-right">
+                                                            <div className="text-sm font-semibold">
+                                                                {item.currency} {formatNumber(item.price, localeCode)}
+                                                            </div>
+                                                            <div className={cn("text-xs font-semibold", getQuoteTone(item.change))}>
+                                                                {item.change !== null && item.change >= 0 ? "+" : ""}
+                                                                {formatNumber(item.change, localeCode)} ({item.changePercent !== null && (item.changePercent || 0) >= 0 ? "+" : ""}
+                                                                {formatNumber(item.changePercent, localeCode)}%)
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div className="flex gap-2">
+                                                        <select
+                                                            value={mostActiveActions[item.yahooSymbol] || "add"}
+                                                            onChange={(event) => {
+                                                                const next = event.target.value as "add" | "chart" | "ask" | "news";
+                                                                setMostActiveActions((prev) => ({ ...prev, [item.yahooSymbol]: next }));
+                                                            }}
+                                                            className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2 text-xs"
+                                                        >
+                                                            <option value="add">{isEnglish ? "Add Watchlist" : "加入自選股"}</option>
+                                                            <option value="chart">{isEnglish ? "View K-line" : "看 K 線"}</option>
+                                                            <option value="ask">{isEnglish ? "Ask Golem (Single)" : "單一送 Golem 分析"}</option>
+                                                            <option value="news">{isEnglish ? "Load News" : "看新聞"}</option>
+                                                        </select>
+                                                        <Button
+                                                            type="button"
+                                                            size="sm"
+                                                            className="h-7 px-2 text-xs"
+                                                            onClick={() => void handleMostActiveAction(item)}
+                                                            disabled={isSending}
+                                                        >
+                                                            {isEnglish ? "Run" : "執行"}
+                                                        </Button>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+                                        {isEnglish ? "No leaderboard data yet." : "暫無排行榜資料。"}
+                                    </div>
+                                )}
+                                {!!mostActiveItems.length && (
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-8 w-full text-xs"
+                                        onClick={() => setShowAllMostActive((prev) => !prev)}
+                                    >
+                                        {showAllMostActive
+                                            ? (isEnglish ? "Show Top 20" : "只看前 20")
+                                            : (isEnglish ? "Expand to Top 50" : "展開到 Top 50")}
+                                    </Button>
+                                )}
                             </CardContent>
                         </Card>
 
@@ -1973,7 +2278,66 @@ export default function CryptoAnalysisPage() {
                                         ? "Send live quotes, indicators, search context, and watchlist breadth as a structured snapshot."
                                         : "把即時行情、技術指標、搜尋脈絡與自選股廣度整理成快照。"}
                                 </p>
-                                <Button className="w-full" onClick={handleAskGolem} disabled={isSending || !selectedQuote}>
+                                <div className="space-y-2">
+                                    <label className="text-xs font-semibold text-foreground">
+                                        {isEnglish ? "Analysis Method" : "分析方法"}
+                                    </label>
+                                    <select
+                                        value={analysisMethod}
+                                        onChange={(event) => setAnalysisMethod(event.target.value as CryptoAnalysisMethodKey)}
+                                        className="h-9 w-full rounded-md border border-border bg-background px-2 text-sm"
+                                    >
+                                        {CRYPTO_ANALYSIS_METHODS.map((method) => (
+                                            <option key={method.key} value={method.key}>
+                                                {isEnglish ? method.labelEn : method.labelZh}
+                                            </option>
+                                        ))}
+                                    </select>
+                                    <p className="text-xs text-muted-foreground">
+                                        {isEnglish ? selectedAnalysisMethod.explainEn : selectedAnalysisMethod.explainZh}
+                                    </p>
+                                </div>
+                                <div className="space-y-2">
+                                    <label className="text-xs font-semibold text-foreground">
+                                        {isEnglish ? "Analysis Scope" : "分析範圍"}
+                                    </label>
+                                    <select
+                                        value={analysisScope}
+                                        onChange={(event) => setAnalysisScope(event.target.value as AnalysisScope)}
+                                        className="h-9 w-full rounded-md border border-border bg-background px-2 text-sm"
+                                    >
+                                        <option value="selected">{isEnglish ? "Selected symbol only" : "僅目前標的"}</option>
+                                        <option value="watchlist">{isEnglish ? "Entire watchlist" : "全部自選"}</option>
+                                    </select>
+                                    <p className="text-xs text-muted-foreground">
+                                        {analysisScope === "selected"
+                                            ? (isEnglish ? "Only the current symbol snapshot will be sent to Golem." : "只會把目前標的快照送給 Golem。")
+                                            : (isEnglish ? "All watchlist symbols will be included in the snapshot." : "會把全部自選標的一起送進快照。")}
+                                    </p>
+                                </div>
+                                <div className="space-y-2">
+                                    <div className="flex items-center justify-between">
+                                        <label className="text-xs font-semibold text-foreground">
+                                            {isEnglish ? "Prompt for Golem" : "給 Golem 的分析 Prompt"}
+                                        </label>
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="sm"
+                                            className="h-7 px-2 text-xs"
+                                            onClick={() => setAnalysisPrompt(buildCryptoPromptTemplate(analysisMethod, isEnglish))}
+                                        >
+                                            {isEnglish ? "Reset template" : "重設模板"}
+                                        </Button>
+                                    </div>
+                                    <textarea
+                                        value={analysisPrompt}
+                                        onChange={(event) => setAnalysisPrompt(event.target.value)}
+                                        className="min-h-[96px] w-full rounded-md border border-border bg-background px-2 py-2 text-sm leading-5"
+                                        placeholder={isEnglish ? "Write strategy prompt..." : "輸入分析策略提示..."}
+                                    />
+                                </div>
+                                <Button className="w-full" onClick={() => void handleAskGolem()} disabled={isSending || !selectedQuote}>
                                     {sentSnapshot ? <Check className="mr-2 h-4 w-4" /> : <Sparkles className="mr-2 h-4 w-4" />}
                                     {isSending ? (isEnglish ? "Sending..." : "送出中...") : (isEnglish ? "Ask Golem" : "請 Golem 分析")}
                                 </Button>
@@ -1989,42 +2353,55 @@ export default function CryptoAnalysisPage() {
                                 <CardDescription>{isEnglish ? "Candlestick Trend" : "K 線趨勢"}</CardDescription>
                                 <CardTitle className="mt-1 text-xl">{selectedQuote?.symbol || displaySymbol(selectedSymbol)} · {selectedQuote?.name || "--"}</CardTitle>
                             </div>
-                            <div className="inline-flex rounded-lg border border-border bg-background p-1">
-                                {(Object.keys(RANGE_MAP) as RangeKey[]).map((option) => (
-                                    <button
-                                        key={option}
-                                        type="button"
-                                        onClick={() => setRange(option)}
-                                        className={cn(
-                                            "h-8 min-w-10 rounded-md px-2 text-xs font-semibold transition-colors",
-                                            range === option ? "bg-secondary text-foreground" : "text-muted-foreground hover:bg-accent hover:text-foreground"
-                                        )}
+                            <div className="flex flex-wrap items-center justify-end gap-2">
+                                <select
+                                    value={selectedSymbol}
+                                    onChange={(event) => setSelectedSymbol(event.target.value)}
+                                    className="h-8 rounded-md border border-border bg-background px-2 text-xs"
+                                >
+                                    {visibleQuotes.map((quote) => (
+                                        <option key={`chart-${quote.yahooSymbol}`} value={quote.yahooSymbol}>
+                                            {quote.symbol} · {quote.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <div className="inline-flex rounded-lg border border-border bg-background p-1">
+                                    {(Object.keys(RANGE_MAP) as RangeKey[]).map((option) => (
+                                        <button
+                                            key={option}
+                                            type="button"
+                                            onClick={() => setRange(option)}
+                                            className={cn(
+                                                "h-8 min-w-10 rounded-md px-2 text-xs font-semibold transition-colors",
+                                                range === option ? "bg-secondary text-foreground" : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                                            )}
+                                        >
+                                            {RANGE_MAP[option].label}
+                                        </button>
+                                    ))}
+                                </div>
+                                <div className="flex items-center gap-1">
+                                    <Button
+                                        size="icon"
+                                        variant="outline"
+                                        className="h-8 w-8"
+                                        onClick={panChartLeft}
+                                        disabled={!canPanChartLeft}
+                                        title={isEnglish ? "Move left" : "往左移動"}
                                     >
-                                        {RANGE_MAP[option].label}
-                                    </button>
-                                ))}
-                            </div>
-                            <div className="flex items-center gap-1">
-                                <Button
-                                    size="icon"
-                                    variant="outline"
-                                    className="h-8 w-8"
-                                    onClick={panChartLeft}
-                                    disabled={!canPanChartLeft}
-                                    title={isEnglish ? "Move left" : "往左移動"}
-                                >
-                                    <ChevronLeft className="h-4 w-4" />
-                                </Button>
-                                <Button
-                                    size="icon"
-                                    variant="outline"
-                                    className="h-8 w-8"
-                                    onClick={panChartRight}
-                                    disabled={!canPanChartRight}
-                                    title={isEnglish ? "Move right" : "往右移動"}
-                                >
-                                    <ChevronRight className="h-4 w-4" />
-                                </Button>
+                                        <ChevronLeft className="h-4 w-4" />
+                                    </Button>
+                                    <Button
+                                        size="icon"
+                                        variant="outline"
+                                        className="h-8 w-8"
+                                        onClick={panChartRight}
+                                        disabled={!canPanChartRight}
+                                        title={isEnglish ? "Move right" : "往右移動"}
+                                    >
+                                        <ChevronRight className="h-4 w-4" />
+                                    </Button>
+                                </div>
                             </div>
                         </CardHeader>
                         <CardContent className="space-y-5">

--- a/web-dashboard/src/app/dashboard/stocks/page.tsx
+++ b/web-dashboard/src/app/dashboard/stocks/page.tsx
@@ -67,6 +67,19 @@ type StockQuote = {
     volume: number;
     turnover: number;
     marketCap: number | null;
+    trailingPE?: number | null;
+    forwardPE?: number | null;
+    priceToBook?: number | null;
+    beta?: number | null;
+    dividendYield?: number | null;
+    dividendRate?: number | null;
+    payoutRatio?: number | null;
+    epsTrailingTwelveMonths?: number | null;
+    epsForward?: number | null;
+    recommendationKey?: string | null;
+    targetMeanPrice?: number | null;
+    numberOfAnalystOpinions?: number | null;
+    sharesOutstanding?: number | null;
     sector: string;
     dataSource: string;
     lastUpdatedAt: string;
@@ -164,6 +177,25 @@ type NewsResponse = {
 type SnapshotRefreshResponse = {
     snapshot?: StockDashboardSnapshot;
 };
+type MostActiveItem = {
+    symbol: string;
+    yahooSymbol: string;
+    name: string;
+    volume: number;
+    price: number | null;
+    change: number | null;
+    changePercent: number | null;
+    previousClose: number | null;
+    market: "tw" | "us";
+    currency: string;
+    source: string;
+};
+type MostActiveResponse = {
+    success?: boolean;
+    market?: "tw" | "us";
+    items?: MostActiveItem[];
+    generatedAt?: string;
+};
 
 type StockDashboardSnapshot = {
     source: string;
@@ -190,6 +222,8 @@ type StockDashboardSnapshot = {
         previousSavedAt: string | null;
     };
 };
+type StockAnalysisMethodKey = "balanced" | "trend_following" | "mean_reversion" | "risk_control";
+type AnalysisScope = "selected" | "watchlist";
 
 const WATCHLIST_STORAGE_KEY = "golem-stock-watchlist-v1";
 const SUPPORT_PROMPT_STORAGE_KEY = "golem-stock-support-prompt-snoozed-at-v1";
@@ -267,6 +301,12 @@ const SUPPORT_COPY_VARIANTS = [
 ];
 const TAIWAN_SYMBOL_RE = /^\d{4,6}[A-Z]{0,3}$/;
 const TAIWAN_YAHOO_SYMBOL_RE = /^\d{4,6}[A-Z]{0,3}\.(TW|TWO)$/;
+const SYMBOL_ALIASES: Record<string, string> = {
+    TPEX: "^TWOII",
+    OTC: "^TWOII",
+    TAIEX: "^TWII",
+    TWSE: "^TWII",
+};
 const RANGE_MAP: Record<RangeKey, { range: string; interval: string }> = {
     "1D": { range: "1d", interval: "5m" },
     "1M": { range: "1mo", interval: "1d" },
@@ -274,10 +314,57 @@ const RANGE_MAP: Record<RangeKey, { range: string; interval: string }> = {
     "6M": { range: "6mo", interval: "1d" },
     "1Y": { range: "1y", interval: "1d" },
 };
+const STOCK_ANALYSIS_METHODS: Array<{
+    key: StockAnalysisMethodKey;
+    labelZh: string;
+    labelEn: string;
+    explainZh: string;
+    explainEn: string;
+    promptZh: string;
+    promptEn: string;
+}> = [
+    {
+        key: "balanced",
+        labelZh: "平衡評估",
+        labelEn: "Balanced",
+        explainZh: "綜合趨勢、動能、量能與新聞，給出保守且可執行的建議。",
+        explainEn: "Combines trend, momentum, volume, and news for a conservative actionable plan.",
+        promptZh: "請做平衡型分析：先判斷趨勢，再看動能與量能，最後給出三種情境（偏多/中性/偏空）與對應行動。",
+        promptEn: "Run a balanced analysis: trend first, then momentum/volume, then provide bullish/neutral/bearish scenarios with actions.",
+    },
+    {
+        key: "trend_following",
+        labelZh: "趨勢追蹤",
+        labelEn: "Trend Following",
+        explainZh: "以趨勢延續為主，重視均線結構、突破與回踩。",
+        explainEn: "Focuses on continuation setups, MA structure, breakouts, and pullbacks.",
+        promptZh: "請以趨勢追蹤角度分析：確認多空方向、關鍵突破位/失效位，給出順勢入場與出場條件。",
+        promptEn: "Analyze with trend-following logic: direction, breakout/invalidation levels, and trend-continuation entry/exit criteria.",
+    },
+    {
+        key: "mean_reversion",
+        labelZh: "均值回歸",
+        labelEn: "Mean Reversion",
+        explainZh: "以超漲超跌回歸為主，重視 RSI、偏離均線與波動收斂。",
+        explainEn: "Targets overextension pullbacks using RSI, MA deviation, and volatility compression.",
+        promptZh: "請以均值回歸角度分析：判斷是否超漲/超跌，提出分批進出與失效條件。",
+        promptEn: "Analyze for mean reversion: detect overbought/oversold states, then propose scaled entries/exits and invalidation.",
+    },
+    {
+        key: "risk_control",
+        labelZh: "風險控管",
+        labelEn: "Risk Control",
+        explainZh: "以資金保全優先，重點是倉位、停損與風險報酬比。",
+        explainEn: "Capital preservation first, emphasizing sizing, stop-loss, and risk/reward.",
+        promptZh: "請以風險控管為主：給出建議倉位%、停損區間、停利區間，並說明不進場的條件。",
+        promptEn: "Prioritize risk control: propose position size %, stop/target zones, and clear no-trade conditions.",
+    },
+];
 
 function normalizeSymbol(input: string) {
     const value = String(input || "").trim().toUpperCase().replace(/\s+/g, "");
     if (!value) return "";
+    if (SYMBOL_ALIASES[value]) return SYMBOL_ALIASES[value];
     if (TAIWAN_SYMBOL_RE.test(value)) return `${value}.TW`;
     if (TAIWAN_YAHOO_SYMBOL_RE.test(value)) return value;
     return value;
@@ -370,6 +457,16 @@ function getFreshnessLabel(value: string, localeCode: string) {
         hour: "2-digit",
         minute: "2-digit",
     }).format(new Date(parsed));
+}
+
+function getStockMethodLabel(method: StockAnalysisMethodKey, isEnglish: boolean) {
+    const found = STOCK_ANALYSIS_METHODS.find((item) => item.key === method) || STOCK_ANALYSIS_METHODS[0];
+    return isEnglish ? found.labelEn : found.labelZh;
+}
+
+function buildStockPromptTemplate(method: StockAnalysisMethodKey, isEnglish: boolean) {
+    const found = STOCK_ANALYSIS_METHODS.find((item) => item.key === method) || STOCK_ANALYSIS_METHODS[0];
+    return isEnglish ? found.promptEn : found.promptZh;
 }
 
 function calculateSmaAt(points: Array<{ close: number }>, index: number, period: number) {
@@ -532,11 +629,19 @@ export default function StockAnalysisPage() {
     const [isLoadingNews, setIsLoadingNews] = useState(false);
     const [isSearching, setIsSearching] = useState(false);
     const [isSending, setIsSending] = useState(false);
+    const [isLoadingMostActive, setIsLoadingMostActive] = useState(false);
     const [sentSnapshot, setSentSnapshot] = useState(false);
+    const [analysisMethod, setAnalysisMethod] = useState<StockAnalysisMethodKey>("balanced");
+    const [analysisScope, setAnalysisScope] = useState<AnalysisScope>("selected");
+    const [analysisPrompt, setAnalysisPrompt] = useState("");
     const [lastUpdatedAt, setLastUpdatedAt] = useState("");
     const [isMounted, setIsMounted] = useState(false);
     const [showSupportPrompt, setShowSupportPrompt] = useState(false);
     const [supportCopyIndex, setSupportCopyIndex] = useState(0);
+    const [mostActiveItems, setMostActiveItems] = useState<MostActiveItem[]>([]);
+    const [showAllMostActive, setShowAllMostActive] = useState(false);
+    const [mostActiveMarket, setMostActiveMarket] = useState<"tw" | "us">("tw");
+    const [mostActiveActions, setMostActiveActions] = useState<Record<string, "add" | "chart" | "ask" | "news">>({});
     const [isFeatureEnabled, setIsFeatureEnabled] = useState(true);
     const [isSidebarHidden, setIsSidebarHidden] = useState(false);
     const lastInteractionRefreshRef = useRef(0);
@@ -633,12 +738,26 @@ export default function StockAnalysisPage() {
         }
     }, [isEnglish, toast]);
 
+    const loadMostActive = useCallback(async () => {
+        setIsLoadingMostActive(true);
+        try {
+            const data = await apiGet<MostActiveResponse>(apiUrl(`/api/stocks/most-active?market=${mostActiveMarket}&limit=50`));
+            setMostActiveItems(Array.isArray(data.items) ? data.items : []);
+        } catch (error) {
+            console.warn("[Stocks] Failed to load most active list:", error);
+            setMostActiveItems([]);
+        } finally {
+            setIsLoadingMostActive(false);
+        }
+    }, [mostActiveMarket]);
+
     const refreshDashboard = useCallback(async () => {
         await Promise.all([
             loadQuotes(),
             loadHistory(selectedSymbol, range),
+            loadMostActive(),
         ]);
-    }, [loadHistory, loadQuotes, range, selectedSymbol]);
+    }, [loadHistory, loadMostActive, loadQuotes, range, selectedSymbol]);
 
     const loadNews = useCallback(async (quote: StockQuote | null) => {
         if (!quote?.yahooSymbol) {
@@ -665,6 +784,57 @@ export default function StockAnalysisPage() {
         if (!isRuntimeActive) return;
         loadQuotes();
     }, [isRuntimeActive, loadQuotes]);
+
+    useEffect(() => {
+        if (!isRuntimeActive) return;
+        loadMostActive();
+    }, [isRuntimeActive, loadMostActive]);
+
+    const handleMostActiveAction = async (item: MostActiveItem) => {
+        const action = mostActiveActions[item.yahooSymbol] || "add";
+        if (action === "add") {
+            addSymbol(item.yahooSymbol);
+            return;
+        }
+        if (action === "chart") {
+            setSelectedSymbol(item.yahooSymbol);
+            if (!watchlist.includes(item.yahooSymbol)) {
+                await loadHistory(item.yahooSymbol, range);
+                await loadNews({
+                    symbol: item.symbol,
+                    yahooSymbol: item.yahooSymbol,
+                    name: item.name,
+                    market: item.market,
+                    currency: item.currency || "TWD",
+                    exchangeName: "",
+                    exchangeTimezoneName: "Asia/Taipei",
+                    price: Number(item.price || 0),
+                    previousClose: Number(item.previousClose || 0),
+                    open: null,
+                    dayHigh: null,
+                    dayLow: null,
+                    fiftyTwoWeekHigh: null,
+                    fiftyTwoWeekLow: null,
+                    change: Number(item.change || 0),
+                    changePercent: Number(item.changePercent || 0),
+                    volume: Number(item.volume || 0),
+                    turnover: Number(item.volume || 0) * Number(item.price || 0),
+                    marketCap: null,
+                    sector: item.market === "us" ? "US Equity" : "台股",
+                    dataSource: item.source || "Most Active",
+                    lastUpdatedAt: new Date().toISOString(),
+                });
+            }
+            return;
+        }
+        if (action === "news") {
+            addSymbol(item.yahooSymbol);
+            const quote = quotes.find((q) => q.yahooSymbol === item.yahooSymbol) || null;
+            if (quote) await loadNews(quote);
+            return;
+        }
+        await handleAskGolem(item.yahooSymbol);
+    };
 
     useEffect(() => {
         if (!isRuntimeActive) return;
@@ -773,6 +943,15 @@ export default function StockAnalysisPage() {
         generatedAt: new Date().toISOString(),
     }), [indicators, marketBreadth, news, quoteErrors, range, selectedMarket, selectedQuote, visibleQuotes]);
 
+    const selectedAnalysisMethod = useMemo(
+        () => STOCK_ANALYSIS_METHODS.find((item) => item.key === analysisMethod) || STOCK_ANALYSIS_METHODS[0],
+        [analysisMethod]
+    );
+
+    useEffect(() => {
+        setAnalysisPrompt(buildStockPromptTemplate(analysisMethod, isEnglish));
+    }, [analysisMethod, isEnglish]);
+
     useEffect(() => {
         if (!isRuntimeActive) return;
         if (!selectedQuote || !quotes.length) return;
@@ -804,7 +983,7 @@ export default function StockAnalysisPage() {
         });
     };
 
-    const handleAskGolem = async () => {
+    const handleAskGolem = async (targetSymbol?: string) => {
         if (!activeGolem) {
             toast.warning(
                 isEnglish ? "No active Golem" : "沒有可用的 Golem",
@@ -815,13 +994,28 @@ export default function StockAnalysisPage() {
         setIsSending(true);
         setSentSnapshot(false);
         try {
-            await refreshDashboard();
+            const selectedForRequest = targetSymbol ? normalizeSymbol(targetSymbol) : selectedSymbol;
+            if (targetSymbol) {
+                setSelectedSymbol(selectedForRequest);
+                await Promise.all([
+                    loadQuotes(),
+                    loadHistory(selectedForRequest, range),
+                    loadMostActive(),
+                ]);
+            } else {
+                await refreshDashboard();
+            }
+            const analysisSymbols = targetSymbol
+                ? [selectedForRequest]
+                : analysisScope === "selected"
+                ? [selectedSymbol]
+                : watchlist;
             let snapshotForGolem = snapshot;
             try {
                 const refreshed = await apiPost<SnapshotRefreshResponse>(apiUrl("/api/stocks/snapshot/refresh"), {
                     snapshot,
-                    symbols: watchlist,
-                    selectedSymbol,
+                    symbols: analysisSymbols,
+                    selectedSymbol: selectedForRequest,
                     selectedRange: range,
                     marketFilter: selectedMarket,
                     trigger: "dashboard-before-golem-analysis",
@@ -837,12 +1031,24 @@ export default function StockAnalysisPage() {
                     isEnglish ? `Live refresh failed: ${message}` : `即時刷新失敗：${message}`
                 );
             }
-            const symbolsForPrompt = Array.from(new Set([selectedSymbol, ...watchlist].map(normalizeSymbol).filter(Boolean)));
+            const symbolsForPrompt = Array.from(new Set(analysisSymbols.map(normalizeSymbol).filter(Boolean)));
+            const userPrompt = String(analysisPrompt || "").trim() || buildStockPromptTemplate(analysisMethod, isEnglish);
             const message = [
                 `/stockboard ${symbolsForPrompt.join(" ")}`,
                 isEnglish
-                    ? "Analyze the current Dashboard stock snapshot. The dashboard has just synchronized the latest server-side structured snapshot; use that complete snapshot as the primary source, mention freshness, and avoid guaranteed financial advice."
-                    : "請分析目前 Dashboard 股市看板。Dashboard 已先同步最新的 server-side 結構化快照；請以完整快照為主要資料來源，說明資料新鮮度，且不要做保證式投資建議。",
+                    ? `Analysis method: ${getStockMethodLabel(analysisMethod, true)}`
+                    : `分析方法：${getStockMethodLabel(analysisMethod, false)}`,
+                isEnglish
+                    ? `Analysis scope: ${analysisScope === "selected" ? "selected symbol only" : "entire watchlist"}`
+                    : `分析範圍：${analysisScope === "selected" ? "僅目前標的" : "全部自選"}`,
+                targetSymbol
+                    ? (isEnglish ? "Forced scope: single symbol action from Top Volume list." : "強制範圍：由成交量榜單觸發之單一標的分析。")
+                    : "",
+                isEnglish ? "User strategy prompt:" : "使用者策略提示：",
+                userPrompt,
+                isEnglish
+                    ? "Use the latest Dashboard structured snapshot as primary evidence. Explicitly mention data freshness and uncertainty; avoid guaranteed financial advice."
+                    : "請以最新 Dashboard 結構化快照為主要依據，明確標示資料新鮮度與不確定性，避免保證式投資建議。",
                 snapshotForGolem?.generatedAt
                     ? `${isEnglish ? "Snapshot generated at" : "快照產生時間"}: ${snapshotForGolem.generatedAt}`
                     : "",
@@ -851,7 +1057,9 @@ export default function StockAnalysisPage() {
             setSentSnapshot(true);
             toast.success(
                 isEnglish ? "Snapshot sent" : "已送出看板快照",
-                isEnglish ? "Golem is analyzing the live board in the console." : "Golem 會在控制台裡分析這份即時看板。"
+                isEnglish
+                    ? (targetSymbol ? "Single-symbol analysis sent. Open Chat to view the result." : "Please open Chat to view the analysis result.")
+                    : (targetSymbol ? "已送出單一標的分析，請到交談功能查看結果。" : "請直接到交談功能查看分析結果。")
             );
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
@@ -976,7 +1184,7 @@ export default function StockAnalysisPage() {
                             <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
                             <div className="space-y-1 text-xs leading-5 text-muted-foreground">
                                 <div className="font-semibold text-foreground">{isEnglish ? "How to use" : "使用說明"}</div>
-                                <p>{isEnglish ? "Search a symbol, select a watchlist row, then ask Golem. Quotes refresh every minute while this page is open." : "搜尋股票、點選自選股列，再請 Golem 分析。頁面停留時每分鐘自動刷新行情。"}</p>
+                                <p>{isEnglish ? "Search a symbol, choose an analysis method, edit prompt if needed, then ask Golem. Quotes refresh every minute while this page is open." : "搜尋股票、選擇分析方法、必要時調整 prompt，再請 Golem 分析。頁面停留時每分鐘自動刷新行情。"}</p>
                             </div>
                         </CardContent>
                     </Card>
@@ -1047,7 +1255,7 @@ export default function StockAnalysisPage() {
                                 </div>
                             )}
 
-                            <div className="max-h-[320px] min-h-[146px] overflow-y-auto rounded-lg border border-border bg-secondary/25">
+                            <div className="max-h-[260px] min-h-[120px] overflow-y-auto rounded-lg border border-border bg-secondary/25">
                                 {isSearching ? (
                                     <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
                                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -1075,6 +1283,33 @@ export default function StockAnalysisPage() {
                                         {isEnglish ? "Search by symbol or company name. Taiwan numeric symbols automatically use .TW." : "可搜尋代號或公司名稱。台股數字代號會自動轉成 .TW。"}
                                     </div>
                                 )}
+                            </div>
+                            <div className="space-y-2">
+                                <div className="text-xs text-muted-foreground">
+                                    {isEnglish ? "Quick switch watchlist" : "快速切換自選"}
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                    {visibleQuotes.slice(0, 6).map((quote) => (
+                                        <button
+                                            key={`quick-${quote.yahooSymbol}`}
+                                            type="button"
+                                            onClick={() => setSelectedSymbol(quote.yahooSymbol)}
+                                            className={cn(
+                                                "rounded-md border px-2.5 py-1 text-xs transition-colors",
+                                                selectedSymbol === quote.yahooSymbol
+                                                    ? "border-primary bg-primary/10 text-primary"
+                                                    : "border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground"
+                                            )}
+                                        >
+                                            {quote.symbol}
+                                        </button>
+                                    ))}
+                                    {!visibleQuotes.length && (
+                                        <span className="text-xs text-muted-foreground">
+                                            {isEnglish ? "No watchlist symbols yet." : "尚未有自選標的。"}
+                                        </span>
+                                    )}
+                                </div>
                             </div>
                         </CardContent>
                     </Card>
@@ -1105,30 +1340,149 @@ export default function StockAnalysisPage() {
                                         ? `${selectedQuote.dataSource}${selectedQuote.dataQuality === "stale-cache" ? (isEnglish ? " · stale cache" : " · 快取資料") : ""} · ${getFreshnessLabel(selectedQuote.lastUpdatedAt, localeCode)}`
                                         : isEnglish ? "No quote selected." : "尚未選取行情。"}
                                 </p>
+                                <div className="grid grid-cols-2 gap-2 text-xs">
+                                    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+                                        <div className="text-muted-foreground">{isEnglish ? "Market Cap" : "市值"}</div>
+                                        <div className="mt-0.5 font-semibold">{formatCompact(selectedQuote?.marketCap, localeCode)}</div>
+                                    </div>
+                                    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+                                        <div className="text-muted-foreground">{isEnglish ? "Trailing PE" : "本益比(TTM)"}</div>
+                                        <div className="mt-0.5 font-semibold">{formatNumber(selectedQuote?.trailingPE, localeCode, 2)}</div>
+                                    </div>
+                                    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+                                        <div className="text-muted-foreground">{isEnglish ? "Forward PE" : "預估本益比"}</div>
+                                        <div className="mt-0.5 font-semibold">{formatNumber(selectedQuote?.forwardPE, localeCode, 2)}</div>
+                                    </div>
+                                    <div className="rounded-md border border-border bg-background px-2 py-1.5">
+                                        <div className="text-muted-foreground">{isEnglish ? "Dividend Yield" : "股息殖利率"}</div>
+                                        <div className="mt-0.5 font-semibold">
+                                            {selectedQuote?.dividendYield == null ? "--" : `${formatNumber(selectedQuote.dividendYield * 100, localeCode, 2)}%`}
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="rounded-lg border border-border/70 bg-secondary/30 p-2.5">
+                                    <div className="mb-2 text-xs text-muted-foreground">{isEnglish ? "Market Breadth" : "市場廣度"}</div>
+                                    <div className="grid grid-cols-3 gap-2">
+                                        <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-2 py-1.5">
+                                            <div className="text-[11px] text-muted-foreground">{isEnglish ? "Up" : "上漲"}</div>
+                                            <div className="text-base font-semibold text-emerald-600 dark:text-emerald-400">{marketBreadth.advancers}</div>
+                                        </div>
+                                        <div className="rounded-md border border-rose-500/20 bg-rose-500/10 px-2 py-1.5">
+                                            <div className="text-[11px] text-muted-foreground">{isEnglish ? "Down" : "下跌"}</div>
+                                            <div className="text-base font-semibold text-rose-600 dark:text-rose-400">{marketBreadth.decliners}</div>
+                                        </div>
+                                        <div className="rounded-md border border-sky-500/20 bg-sky-500/10 px-2 py-1.5">
+                                            <div className="text-[11px] text-muted-foreground">{isEnglish ? "Avg" : "平均"}</div>
+                                            <div className={cn("text-base font-semibold", getQuoteTone(marketBreadth.averageMove))}>
+                                                {marketBreadth.averageMove >= 0 ? "+" : ""}
+                                                {formatNumber(marketBreadth.averageMove, localeCode)}%
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </CardContent>
                         </Card>
 
                         <Card className="rounded-lg border-border/80">
                             <CardHeader className="pb-3">
-                                <CardDescription>{isEnglish ? "Market Breadth" : "市場廣度"}</CardDescription>
-                                <CardTitle className="text-xl">{isEnglish ? "Watchlist Pulse" : "自選股脈動"}</CardTitle>
+                                <CardDescription>{isEnglish ? "Previous Session Leaderboard" : "前一交易日排行榜"}</CardDescription>
+                                <CardTitle className="text-xl">{isEnglish ? "Top 50 by Volume" : "成交量 Top 50"}</CardTitle>
                             </CardHeader>
-                            <CardContent className="grid grid-cols-3 gap-3">
-                                <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
-                                    <div className="text-xs text-muted-foreground">{isEnglish ? "Up" : "上漲"}</div>
-                                    <div className="mt-1 text-2xl font-semibold text-emerald-600 dark:text-emerald-400">{marketBreadth.advancers}</div>
+                            <CardContent className="space-y-3">
+                                <div className="flex items-center gap-2">
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant={mostActiveMarket === "tw" ? "default" : "outline"}
+                                        className="h-7 px-2 text-xs"
+                                        onClick={() => setMostActiveMarket("tw")}
+                                    >
+                                        {isEnglish ? "Taiwan" : "台股"}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant={mostActiveMarket === "us" ? "default" : "outline"}
+                                        className="h-7 px-2 text-xs"
+                                        onClick={() => setMostActiveMarket("us")}
+                                    >
+                                        {isEnglish ? "US" : "美股"}
+                                    </Button>
                                 </div>
-                                <div className="rounded-lg border border-rose-500/20 bg-rose-500/10 p-3">
-                                    <div className="text-xs text-muted-foreground">{isEnglish ? "Down" : "下跌"}</div>
-                                    <div className="mt-1 text-2xl font-semibold text-rose-600 dark:text-rose-400">{marketBreadth.decliners}</div>
-                                </div>
-                                <div className="rounded-lg border border-sky-500/20 bg-sky-500/10 p-3">
-                                    <div className="text-xs text-muted-foreground">{isEnglish ? "Avg" : "平均"}</div>
-                                    <div className={cn("mt-1 text-2xl font-semibold", getQuoteTone(marketBreadth.averageMove))}>
-                                        {marketBreadth.averageMove >= 0 ? "+" : ""}
-                                        {formatNumber(marketBreadth.averageMove, localeCode)}%
+                                {isLoadingMostActive ? (
+                                    <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                        {isEnglish ? "Loading active symbols..." : "讀取熱門成交標的中..."}
                                     </div>
-                                </div>
+                                ) : mostActiveItems.length ? (
+                                    <div className="max-h-[310px] overflow-y-auto rounded-lg border border-border bg-background/40">
+                                        <div className="divide-y divide-border/70">
+                                            {mostActiveItems.slice(0, showAllMostActive ? 50 : 20).map((item) => (
+                                                <div key={`active-${item.yahooSymbol}`} className="space-y-2 px-3 py-2.5">
+                                                    <div className="flex items-start justify-between gap-2">
+                                                        <div className="min-w-0">
+                                                            <div className="truncate text-sm font-semibold">{item.symbol} · {item.name}</div>
+                                                            <div className="text-xs text-muted-foreground">
+                                                                {isEnglish ? "Volume" : "成交量"} {formatCompact(item.volume, localeCode)}
+                                                            </div>
+                                                        </div>
+                                                        <div className="text-right">
+                                                            <div className="text-sm font-semibold">
+                                                                {item.currency} {formatNumber(item.price, localeCode)}
+                                                            </div>
+                                                            <div className={cn("text-xs font-semibold", getQuoteTone(item.change))}>
+                                                                {item.change !== null && item.change >= 0 ? "+" : ""}
+                                                                {formatNumber(item.change, localeCode)} ({item.changePercent !== null && (item.changePercent || 0) >= 0 ? "+" : ""}
+                                                                {formatNumber(item.changePercent, localeCode)}%)
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div className="flex gap-2">
+                                                        <select
+                                                            value={mostActiveActions[item.yahooSymbol] || "add"}
+                                                            onChange={(event) => {
+                                                                const next = event.target.value as "add" | "chart" | "ask" | "news";
+                                                                setMostActiveActions((prev) => ({ ...prev, [item.yahooSymbol]: next }));
+                                                            }}
+                                                            className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2 text-xs"
+                                                        >
+                                                            <option value="add">{isEnglish ? "Add Watchlist" : "加入自選股"}</option>
+                                                            <option value="chart">{isEnglish ? "View K-line" : "看 K 線"}</option>
+                                                            <option value="ask">{isEnglish ? "Ask Golem (Single)" : "單一送 Golem 分析"}</option>
+                                                            <option value="news">{isEnglish ? "Load News" : "看新聞"}</option>
+                                                        </select>
+                                                        <Button
+                                                            type="button"
+                                                            size="sm"
+                                                            className="h-7 px-2 text-xs"
+                                                            onClick={() => void handleMostActiveAction(item)}
+                                                            disabled={isSending}
+                                                        >
+                                                            {isEnglish ? "Run" : "執行"}
+                                                        </Button>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
+                                        {isEnglish ? "No leaderboard data yet." : "暫無排行榜資料。"}
+                                    </div>
+                                )}
+                                {!!mostActiveItems.length && (
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-8 w-full text-xs"
+                                        onClick={() => setShowAllMostActive((prev) => !prev)}
+                                    >
+                                        {showAllMostActive
+                                            ? (isEnglish ? "Show Top 20" : "只看前 20")
+                                            : (isEnglish ? "Expand to Top 50" : "展開到 Top 50")}
+                                    </Button>
+                                )}
                             </CardContent>
                         </Card>
 
@@ -1146,7 +1500,66 @@ export default function StockAnalysisPage() {
                                         ? "Send live quotes, indicators, search context, and watchlist breadth as a structured snapshot."
                                         : "把即時行情、技術指標、搜尋脈絡與自選股廣度整理成快照。"}
                                 </p>
-                                <Button className="w-full" onClick={handleAskGolem} disabled={isSending || !selectedQuote}>
+                                <div className="space-y-2">
+                                    <label className="text-xs font-semibold text-foreground">
+                                        {isEnglish ? "Analysis Method" : "分析方法"}
+                                    </label>
+                                    <select
+                                        value={analysisMethod}
+                                        onChange={(event) => setAnalysisMethod(event.target.value as StockAnalysisMethodKey)}
+                                        className="h-9 w-full rounded-md border border-border bg-background px-2 text-sm"
+                                    >
+                                        {STOCK_ANALYSIS_METHODS.map((method) => (
+                                            <option key={method.key} value={method.key}>
+                                                {isEnglish ? method.labelEn : method.labelZh}
+                                            </option>
+                                        ))}
+                                    </select>
+                                    <p className="text-xs text-muted-foreground">
+                                        {isEnglish ? selectedAnalysisMethod.explainEn : selectedAnalysisMethod.explainZh}
+                                    </p>
+                                </div>
+                                <div className="space-y-2">
+                                    <label className="text-xs font-semibold text-foreground">
+                                        {isEnglish ? "Analysis Scope" : "分析範圍"}
+                                    </label>
+                                    <select
+                                        value={analysisScope}
+                                        onChange={(event) => setAnalysisScope(event.target.value as AnalysisScope)}
+                                        className="h-9 w-full rounded-md border border-border bg-background px-2 text-sm"
+                                    >
+                                        <option value="selected">{isEnglish ? "Selected symbol only" : "僅目前標的"}</option>
+                                        <option value="watchlist">{isEnglish ? "Entire watchlist" : "全部自選"}</option>
+                                    </select>
+                                    <p className="text-xs text-muted-foreground">
+                                        {analysisScope === "selected"
+                                            ? (isEnglish ? "Only the current symbol snapshot will be sent to Golem." : "只會把目前標的快照送給 Golem。")
+                                            : (isEnglish ? "All watchlist symbols will be included in the snapshot." : "會把全部自選標的一起送進快照。")}
+                                    </p>
+                                </div>
+                                <div className="space-y-2">
+                                    <div className="flex items-center justify-between">
+                                        <label className="text-xs font-semibold text-foreground">
+                                            {isEnglish ? "Prompt for Golem" : "給 Golem 的分析 Prompt"}
+                                        </label>
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="sm"
+                                            className="h-7 px-2 text-xs"
+                                            onClick={() => setAnalysisPrompt(buildStockPromptTemplate(analysisMethod, isEnglish))}
+                                        >
+                                            {isEnglish ? "Reset template" : "重設模板"}
+                                        </Button>
+                                    </div>
+                                    <textarea
+                                        value={analysisPrompt}
+                                        onChange={(event) => setAnalysisPrompt(event.target.value)}
+                                        className="min-h-[96px] w-full rounded-md border border-border bg-background px-2 py-2 text-sm leading-5"
+                                        placeholder={isEnglish ? "Write strategy prompt..." : "輸入分析策略提示..."}
+                                    />
+                                </div>
+                                <Button className="w-full" onClick={() => void handleAskGolem()} disabled={isSending || !selectedQuote}>
                                     {sentSnapshot ? <Check className="mr-2 h-4 w-4" /> : <Sparkles className="mr-2 h-4 w-4" />}
                                     {isSending ? (isEnglish ? "Sending..." : "送出中...") : (isEnglish ? "Ask Golem" : "請 Golem 分析")}
                                 </Button>
@@ -1162,20 +1575,33 @@ export default function StockAnalysisPage() {
                                 <CardDescription>{isEnglish ? "Candlestick Trend" : "K 線趨勢"}</CardDescription>
                                 <CardTitle className="mt-1 text-xl">{selectedQuote?.symbol || displaySymbol(selectedSymbol)} · {selectedQuote?.name || "--"}</CardTitle>
                             </div>
-                            <div className="inline-flex rounded-lg border border-border bg-background p-1">
-                                {(Object.keys(RANGE_MAP) as RangeKey[]).map((option) => (
-                                    <button
-                                        key={option}
-                                        type="button"
-                                        onClick={() => setRange(option)}
-                                        className={cn(
-                                            "h-8 min-w-10 rounded-md px-2 text-xs font-semibold transition-colors",
-                                            range === option ? "bg-secondary text-foreground" : "text-muted-foreground hover:bg-accent hover:text-foreground"
-                                        )}
-                                    >
-                                        {option}
-                                    </button>
-                                ))}
+                            <div className="flex flex-wrap items-center justify-end gap-2">
+                                <select
+                                    value={selectedSymbol}
+                                    onChange={(event) => setSelectedSymbol(event.target.value)}
+                                    className="h-8 rounded-md border border-border bg-background px-2 text-xs"
+                                >
+                                    {visibleQuotes.map((quote) => (
+                                        <option key={`chart-${quote.yahooSymbol}`} value={quote.yahooSymbol}>
+                                            {quote.symbol} · {quote.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <div className="inline-flex rounded-lg border border-border bg-background p-1">
+                                    {(Object.keys(RANGE_MAP) as RangeKey[]).map((option) => (
+                                        <button
+                                            key={option}
+                                            type="button"
+                                            onClick={() => setRange(option)}
+                                            className={cn(
+                                                "h-8 min-w-10 rounded-md px-2 text-xs font-semibold transition-colors",
+                                                range === option ? "bg-secondary text-foreground" : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                                            )}
+                                        >
+                                            {option}
+                                        </button>
+                                    ))}
+                                </div>
                             </div>
                         </CardHeader>
                         <CardContent className="space-y-5">
@@ -1261,7 +1687,7 @@ export default function StockAnalysisPage() {
                                         tone: getQuoteTone(selectedQuote?.change),
                                     },
                                     { label: isEnglish ? "Volume" : "成交量", value: formatCompact(selectedQuote?.volume, localeCode) },
-                                    { label: isEnglish ? "Mkt Cap" : "市值", value: formatCompact(selectedQuote?.marketCap, localeCode) },
+                                    { label: isEnglish ? "Turnover" : "成交值", value: formatCompact(selectedQuote?.turnover, localeCode) },
                                 ].map((item) => (
                                     <div key={item.label} className="rounded-lg border border-border bg-background p-3">
                                         <div className="text-xs text-muted-foreground">{item.label}</div>


### PR DESCRIPTION
# v9.7.5 發版說明（中文）

此 PR 發布 `v9.7.5`，重點為強化 Crypto/Stocks 的決策輔助能力。新增 `MarketDecisionEngine` 以統一產出判讀結果、風險旗標與情境模擬，並同步擴充後端 API 與前端 dashboard 顯示，讓使用者從「看數字」升級為「看結論 + 看風險 + 看推演」。同時完成版本與文件同步更新。

## 一般使用者版本

### 版本資訊
- 版本：`v9.7.5`
- 重點：強化「加密貨幣 / 股票」儀表板的決策輔助能力，讓你不只看數字，也能看到更具體的判讀與風險提示。

### 這版有什麼新功能
1. 新增市場決策引擎（Market Decision Engine）
- 系統會根據指標狀態，產出較清楚的判讀結果（例如偏觀望、偏布局、偏減碼）與信心度。

2. 新增情境模擬能力
- 可依輸入條件進行部位風險/報酬推演，協助你在操作前先評估不同走勢下的結果。

3. Crypto / Stocks 儀表板升級
- 前端畫面可呈現更完整的決策資訊與分析內容。
- 後端 API 同步擴充，資料供應與畫面顯示一致。

4. 發版與文件同步
- 專案版本升級為 `v9.7.5`，README/說明文件同步更新。

### 對你有什麼幫助
- 看盤不再只有原始數字，能更快抓到重點與風險。
- 透過情境模擬，操作前就能先估算可能結果。
- Dashboard 的分析流程更完整，判讀更直覺。

---

## 技術版本（給協作者 / Reviewer）

### 本次主要變更檔案
- `package.json`（版本升級至 `9.7.5`）
- `README.md`
- `README.en.md`
- `docs/README.en.md`
- `src/managers/ChatLogManager.js`
- `src/services/MarketDecisionEngine.js`（新增）
- `web-dashboard/routes/api.crypto.js`
- `web-dashboard/routes/api.stocks.js`
- `web-dashboard/src/app/dashboard/crypto/page.tsx`
- `web-dashboard/src/app/dashboard/stocks/page.tsx`

### 技術重點
1. 新增 `MarketDecisionEngine`
- 統一決策計算與風險評估邏輯，包含結論、信心度、風險旗標、檢查建議與情境推演輸出。

2. 擴充 `api.crypto.js` / `api.stocks.js`
- 後端提供更完整決策資料結構，供 dashboard 直接渲染。

3. 升級 `crypto` / `stocks` 頁面
- 前端接入新的決策與模擬結果，提升資訊可讀性與可操作性。

4. `ChatLogManager` 調整
- 配合新版流程做相容更新。

