### PR TITLE
fix: release v9.7.8 with cross-platform env parsing

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,7 +4,7 @@
   <p><strong>Your AI operations hub: chat, act, remember, and collaborate over the long run.</strong></p>
 
   <p>
-    <img src="https://img.shields.io/badge/version-9.7.7-blue?style=for-the-badge" alt="version" />
+    <img src="https://img.shields.io/badge/version-9.7.8-blue?style=for-the-badge" alt="version" />
     <img src="https://img.shields.io/badge/node.js-20~22-3C873A?style=for-the-badge&logo=nodedotjs&logoColor=white" alt="node" />
     <img src="https://img.shields.io/badge/backend-gemini%20web%20%7C%20ollama%20%7C%20lmstudio-orange?style=for-the-badge" alt="backend" />
     <img src="https://img.shields.io/badge/dashboard-next.js-black?style=for-the-badge&logo=nextdotjs" alt="dashboard" />

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p><strong>你的 AI 操作中樞：可對話、可行動、可記憶、可長期協作。</strong></p>
 
   <p>
-    <img src="https://img.shields.io/badge/version-9.7.7-blue?style=for-the-badge" alt="version" />
+    <img src="https://img.shields.io/badge/version-9.7.8-blue?style=for-the-badge" alt="version" />
     <img src="https://img.shields.io/badge/node.js-20~22-3C873A?style=for-the-badge&logo=nodedotjs&logoColor=white" alt="node" />
     <img src="https://img.shields.io/badge/backend-gemini%20web%20%7C%20ollama%20%7C%20lmstudio-orange?style=for-the-badge" alt="backend" />
     <img src="https://img.shields.io/badge/dashboard-next.js-black?style=for-the-badge&logo=nextdotjs" alt="dashboard" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-golem",
-  "version": "9.7.7",
+  "version": "9.7.8",
   "description": "Project Golem v9.5 (Ultimate Chronos + MultiAgent Edition) - Collaborative AI System",
   "main": "index.js",
   "scripts": {

--- a/src/utils/EnvManager.js
+++ b/src/utils/EnvManager.js
@@ -22,7 +22,7 @@ class EnvManager {
         const content = fs.readFileSync(this.envPath, 'utf8');
         const envObj = {};
 
-        content.split('\n').forEach(line => {
+        content.split(/\r\n|\n|\r/).forEach(line => {
             // 略過純註解或空行
             if (!line || line.trim().startsWith('#')) return;
 

--- a/tests/EnvManager.test.js
+++ b/tests/EnvManager.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+
+jest.mock('fs', () => ({
+    existsSync: jest.fn(),
+    readFileSync: jest.fn(),
+}));
+
+const EnvManager = require('../src/utils/EnvManager');
+
+describe('EnvManager', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        fs.existsSync.mockReturnValue(true);
+    });
+
+    test.each([
+        ['LF', 'GEMINI_API_KEYS=abc\nSYSTEM_CONFIGURED=true\n'],
+        ['CRLF', 'GEMINI_API_KEYS=abc\r\nSYSTEM_CONFIGURED=true\r\n'],
+        ['CR', 'GEMINI_API_KEYS=abc\rSYSTEM_CONFIGURED=true\r'],
+    ])('readEnv parses %s line endings', (_lineEnding, content) => {
+        fs.readFileSync.mockReturnValue(content);
+
+        expect(EnvManager.readEnv()).toEqual({
+            GEMINI_API_KEYS: 'abc',
+            SYSTEM_CONFIGURED: 'true',
+        });
+    });
+});


### PR DESCRIPTION
本次變更

* package.json 與中英文 README 更新為 v9.7.8。
* EnvManager 現在可解析三種 .env 換行格式：
    * macOS/Linux 的 LF
    * Windows 的 CRLF
    * 舊式系統的 CR
* 新增 tests/EnvManager.test.js，覆蓋三種換行格式。